### PR TITLE
BUG: disable 2gb file size check in getid3, which causes problems

### DIFF
--- a/lib/extractor.php
+++ b/lib/extractor.php
@@ -32,7 +32,11 @@ class Extractor_GetID3 implements Extractor {
 	public function __construct() {
 		$this->getID3 = @new \getID3();
 		$this->getID3->encoding = 'UTF-8';
-		
+
+		// On 32-bit systems, getid3 tries to make a 2GB size check,
+		// which does not work with fopen. Disable it.
+		$this->getID3->option_max_2gb_check = false;
+
 		// Trying to enable stream support
 		if(ini_get('allow_url_fopen') != 1) {
 			\OCP\Util::writeLog('Media', 'allow_url_fopen is disabled. It is strongly advised to enable it in your php.ini', \OCP\Util::WARN);


### PR DESCRIPTION
The extra check is run only on 32-bit platforms. getid3 ends up calling `ls` via shell, which does not play together with oc:// streamed files opened with fopen.

Only after this change, music files appear in the media player on my server machine. (I.e. the media player is unusable without it.)

Didn't check what happens with > 2GB files with this change. However, that big music files are rather uncommon, and I'd guess getid3 will simply fail to read the tag.
