### PR TITLE
$.placeholder() was renamed to $.imageplaceholder() in master

### DIFF
--- a/js/app/directives/albumart.js
+++ b/js/app/directives/albumart.js
@@ -36,7 +36,7 @@ angular.module('Music').directive('albumart', function() {
 					element.css('-ms-filter', '');
 					element.css('background-image', '');
 					// add placeholder stuff
-					element.placeholder(attrs.albumart);
+					element.imageplaceholder(attrs.albumart);
 				}
 			}
 		};

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -387,7 +387,7 @@ angular.module('Music').directive('albumart', function() {
 					element.css('-ms-filter', '');
 					element.css('background-image', '');
 					// add placeholder stuff
-					element.placeholder(attrs.albumart);
+					element.imageplaceholder(attrs.albumart);
 				}
 			}
 		};


### PR DESCRIPTION
No placeholders show since that. Fixed.

@kabum @Raydiation 
