### PR TITLE
Check for year type

### DIFF
--- a/utility/scanner.php
+++ b/utility/scanner.php
@@ -160,6 +160,10 @@ class Scanner {
 			$year = null;
 			if($hasComments && array_key_exists('year', $fileInfo['comments'])){
 				$year = $fileInfo['comments']['year'][0];
+				if(!ctype_digit($year)) {
+					$year = null;
+				}
+
 			}
 			$mimetype = $metadata['mimetype'];
 			$fileId = $metadata['fileid'];


### PR DESCRIPTION
Since the type is enforced by the DB, if the year is not an int, insert will fail, stopping the scanner.
