### PR TITLE
remove 'owncloud' from unknown artist and album name

### DIFF
--- a/utility/scanner.php
+++ b/utility/scanner.php
@@ -112,8 +112,8 @@ class Scanner {
 				}
 			}
 			if($artist === null || $artist === ''){
-				// fallback to "ownCloud unknown artist"
-				$artist = 'ownCloud unknown artist';
+				// fallback to localized version of "unknown artist"
+				$artist = $this->api->getTrans()->t('Unknown artist');
 			}
 
 			$alternativeTrackNumber = null;
@@ -141,8 +141,8 @@ class Scanner {
 				$album = $fileInfo['comments']['album'][0];
 			}
 			if($album === null || $album === ''){
-				// fallback to "ownCloud unknown album"
-				$album = 'ownCloud unknown album';
+				// fallback to localized version of "unknown album"
+				$album = $this->api->getTrans()->t('Unknown album');
 			}
 
 			// track number


### PR DESCRIPTION
instead use localized string of 'Unknown album' / 'Unknown artist'

Instead of using `OC_Defaults` to customize the productname I completely removed the hardcoded product name. It has nothing to do with the song, really. @kabum Or is there a good reason for prepending the fallback strings with `ownCloud`?
