### PR TITLE
add @method PHPDoc to allow IDEs to show return types for magic methods

### DIFF
--- a/db/album.php
+++ b/db/album.php
@@ -28,6 +28,24 @@ use \OCA\Music\AppFramework\Db\Entity;
 use \OCA\Music\Core\API;
 
 
+/**
+ * @method string getName()
+ * @method setName(string $name)
+ * @method int getYear()
+ * @method setYear(int $year)
+ * @method int getCoverFileId()
+ * @method setCoverFileId(int $coverFileId)
+ * @method string getCoverFilePath()
+ * @method setCoverFilePath(string $coverFilePath)
+ * @method array getArtistIds()
+ * @method setArtistIds(array $artistIds)
+ * @method string getUserId()
+ * @method setUserId(string $userId)
+ * @method int getTrackCount()
+ * @method setTrackCount(int $trackCount)
+ * @method string getArtist()
+ * @method setArtist(string $artist)
+ */
 class Album extends Entity {
 
 	public $name;
@@ -54,6 +72,10 @@ class Album extends Entity {
 		);
 	}
 
+	/**
+	 * @param \OCA\Music\Core\API $api
+	 * @return array
+	 */
 	public function getArtists(API $api) {
 		$artists = array();
 		foreach($this->artistIds as $artistId) {
@@ -68,6 +90,10 @@ class Album extends Entity {
 		return $artists;
 	}
 
+	/**
+	 * @param \OCA\Music\Core\API $api
+	 * @return string
+	 */
 	public function getNameString(API $api) {
 		$name = $this->getName();
 		if ($name === null) {

--- a/db/ampachesession.php
+++ b/db/ampachesession.php
@@ -28,6 +28,14 @@ use \OCA\Music\AppFramework\Db\Entity;
 use \OCA\Music\Core\API;
 
 
+/**
+ * @method string getUserId()
+ * @method setUserId(string $userId)
+ * @method string getToken()
+ * @method setToken(string $token)
+ * @method int getExpiry()
+ * @method setExpiry(int $expiry)
+ */
 class AmpacheSession extends Entity {
 
 	public $userId;

--- a/db/artist.php
+++ b/db/artist.php
@@ -28,6 +28,18 @@ use \OCA\Music\AppFramework\Db\Entity;
 use \OCA\Music\Core\API;
 
 
+/**
+ * @method string getName()
+ * @method setName(string $name)
+ * @method string getImage()
+ * @method setImage(string $image)
+ * @method string getUserId()
+ * @method setUserId(string $userId)
+ * @method int getAlbumCount()
+ * @method setAlbumCount(int $albumCount)
+ * @method int getTrackCount()
+ * @method setTrackCount(int $trackCount)
+ */
 class Artist extends Entity {
 
 	public $name;

--- a/db/track.php
+++ b/db/track.php
@@ -28,6 +28,34 @@ use \OCA\Music\AppFramework\Db\Entity;
 use \OCA\Music\Core\API;
 
 
+/**
+ * @method string getTitle()
+ * @method setTitle(string $title)
+ * @method int getNumber()
+ * @method setNumber(int $number)
+ * @method int getArtistId()
+ * @method setArtistId(int $artistId)
+ * @method string getArtist()
+ * @method setArtist(string $artist)
+ * @method int getAlbumId()
+ * @method setAlbumId(int $albumId)
+ * @method string getAlbum()
+ * @method setAlbum(string $album)
+ * @method int getLength()
+ * @method setLength(int $length)
+ * @method int getFileSize()
+ * @method setFileSize(int $fileSize)
+ * @method int getFileId()
+ * @method setFileId(int $fileId)
+ * @method string getFilePath()
+ * @method setFilePath(string $filePath)
+ * @method int getBitrate()
+ * @method setBitrate(int $bitrate)
+ * @method string getMimetype()
+ * @method setMimetype(string $mimetype)
+ * @method string getUserId()
+ * @method setUserId(string $userId)
+ */
 class Track extends Entity {
 
 	public $title;


### PR DESCRIPTION
just stumbled over this because of scrutinizer ...
