### PR TITLE
fix left alignment issues of artist name and tracks on mobile

### DIFF
--- a/css/mobile.css
+++ b/css/mobile.css
@@ -13,7 +13,7 @@
 }
 
 .artist-area > h1 {
-	margin-left: 14px;
+	margin-left: 8px;
 }
 
 /* adjust album area to screen width */
@@ -64,7 +64,7 @@
 }
 /* align track title to the left with album title */
 .track-list > li {
-	padding-left: 25px;
+	padding-left: 60px;
 }
 
 .track-list > li > .play.playing {


### PR DESCRIPTION
Please check @MorrisJobke @jbtbnl @wakeup 

Before (everything at their own left starting position):
![screenshot from 2014-04-11 08 53 47](https://cloud.githubusercontent.com/assets/925062/2676992/f675bec4-c146-11e3-9269-ef70ac472b0a.png)

After (artist name aligned with covers, tracks aligned with album title – which they are sub-items of):
![screenshot from 2014-04-11 08 59 06](https://cloud.githubusercontent.com/assets/925062/2676994/fcbe20c8-c146-11e3-9f48-724debd576a9.png)
