### PR TITLE
CSS for progress bar

### DIFF
--- a/templates/main.php
+++ b/templates/main.php
@@ -74,8 +74,8 @@ if($version[0] === 6 || ($version[0] === 5 && $version[1] >= 80)) {
 					<span ng-show="loading" class="muted">Loading...</span>
 					<div class="progress">
 						<div class="seek-bar" ng-click="seek($event)">
-							<div class="seek-bar-buffered" style="width: {{ position.buffer }}%"></div>
-							<div class="seek-bar-played" ng-show="position.total" style="width: {{ position.current/position.total * 100 }}%"></div>
+							<div class="buffer-bar" style="width: {{ position.buffer }}%"></div>
+							<div class="play-bar" ng-show="position.total" style="width: {{ position.current/position.total * 100 }}%"></div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
Added css for progressbar.
Now progressbar shows correct played progress and buffered progress.

Seeking doesn't works still cause... `js/public/app.js` contains (lines 449-452):

<pre>
                if($scope.player.format.formatID !== 'flac') {
                        // just in flac seeking is tested
                        return;
                }
</pre>
