### PR TITLE
use temp table for dumb mysql

### DIFF
--- a/utility/helper.php
+++ b/utility/helper.php
@@ -29,11 +29,35 @@ class Helper {
 	 */
 	public function cleanUp() {
 		$sqls = array(
-			'UPDATE `*PREFIX*music_albums` SET `cover_file_id` = NULL WHERE `cover_file_id` IS NOT NULL AND `cover_file_id` IN (SELECT `cover_file_id` FROM `*PREFIX*music_albums` LEFT JOIN `*PREFIX*filecache` ON `cover_file_id`=`fileid` WHERE `fileid` IS NULL);',
-			'DELETE FROM `*PREFIX*music_tracks` WHERE `file_id` IN (SELECT `file_id` FROM `*PREFIX*music_tracks` LEFT JOIN `*PREFIX*filecache` ON `file_id`=`fileid` WHERE `fileid` IS NULL);',
-			'DELETE FROM `*PREFIX*music_albums` WHERE `id` NOT IN (SELECT `album_id` FROM `*PREFIX*music_tracks` GROUP BY `album_id`);',
-			'DELETE FROM `*PREFIX*music_album_artists` WHERE `album_id` NOT IN (SELECT `id` FROM `*PREFIX*music_albums` GROUP BY `id`);',
-			'DELETE FROM `*PREFIX*music_artists` WHERE `id` NOT IN (SELECT `artist_id` FROM `*PREFIX*music_album_artists` GROUP BY `artist_id`);'
+			'UPDATE `*PREFIX*music_albums` SET `cover_file_id` = NULL
+				WHERE `cover_file_id` IS NOT NULL AND `cover_file_id` IN (
+					SELECT `cover_file_id` FROM (
+						SELECT `cover_file_id` FROM `*PREFIX*music_albums`
+						LEFT JOIN `*PREFIX*filecache`
+							ON `cover_file_id`=`fileid`
+						WHERE `fileid` IS NULL
+					) mysqlhack
+				);',
+			'DELETE FROM `*PREFIX*music_tracks` WHERE `file_id` IN (
+				SELECT `file_id` FROM (
+					SELECT `file_id` FROM `*PREFIX*music_tracks`
+					LEFT JOIN `*PREFIX*filecache`
+						ON `file_id`=`fileid`
+					WHERE `fileid` IS NULL
+					) mysqlhack
+				);',
+			'DELETE FROM `*PREFIX*music_albums` WHERE `id` NOT IN (
+					SELECT `album_id` FROM `*PREFIX*music_tracks`
+					GROUP BY `album_id`
+				);',
+			'DELETE FROM `*PREFIX*music_album_artists` WHERE `album_id` NOT IN (
+					SELECT `id` FROM `*PREFIX*music_albums`
+					GROUP BY `id`
+				);',
+			'DELETE FROM `*PREFIX*music_artists` WHERE `id` NOT IN (
+					SELECT `artist_id` FROM `*PREFIX*music_album_artists`
+					GROUP BY `artist_id`
+				);'
 		);
 
 		foreach ($sqls as $sql) {


### PR DESCRIPTION
fixes #358

@rotdrop the JOIN with IS NULL comparison is used to select entries that do NOT have a matching filecache entry (the cover was deleted). see http://explainextended.com/2009/09/18/not-in-vs-not-exists-vs-left-join-is-null-mysql/