### PR TITLE
IDBConnection does not contain "prepareQuery"

### DIFF
--- a/command/resetdatabase.php
+++ b/command/resetdatabase.php
@@ -82,11 +82,11 @@ class ResetDatabase extends Command {
 		$sql = 'DELETE FROM `*PREFIX*music_album_artists` ' .
 			'WHERE `album_id` NOT IN (SELECT `id` FROM `*PREFIX*music_albums`) ' .
 			'OR `artist_id` NOT IN (SELECT `id` FROM `*PREFIX*music_artists`)';
-		$this->db->prepareQuery($sql)->execute();
+		$this->db->prepare($sql)->execute();
 
 		$sql = 'DELETE FROM `*PREFIX*music_playlist_tracks` ' .
 			'WHERE `track_id` NOT IN (SELECT `id` FROM `*PREFIX*music_tracks`)';
-		$this->db->prepareQuery($sql)->execute();
+		$this->db->prepare($sql)->execute();
 	}
 
 }


### PR DESCRIPTION
The IDBConnection interface does not contain a "prepareQuery" method which leads to a "Method not found" error. Using "prepare" instead.