### PR TITLE
Improve cleanup SQL statements

### DIFF
--- a/tests/php/integration/data/HelperCleanupData.json
+++ b/tests/php/integration/data/HelperCleanupData.json
@@ -3,5 +3,14 @@
     { "id" : 1001, "name": "The First Artist",  "user_id": "integration" },
     { "id" : 1002, "name": "The Second Artist", "user_id": "integration" },
     { "id" : 1003, "name": "The Third Artist",  "user_id": "integration" }
+  ],
+  "music_albums" : [
+    { "id" : 1001, "name": "Testalbum",  "user_id": "integration", "year":"2016", "cover_file_id":"0" }
+  ],
+  "music_tracks" : [
+    { "id" : "1001", "user_id": "integration", "title" : "Testtitel 1", "number" : "1", "artist_id" : "1001", "album_id": "1001" , "length" : "100", "file_id" : "0", "bitrate" : "123", "mimetype" : "audio/mpeg"}
+  ],
+  "music_album_artists" : [
+    { "artist_id" : 1001, "album_id": "1001"}
   ]
 }

--- a/utility/helper.php
+++ b/utility/helper.php
@@ -46,18 +46,33 @@ class Helper {
 					WHERE `fileid` IS NULL
 					) mysqlhack
 				);',
-			'DELETE FROM `*PREFIX*music_albums` WHERE `id` NOT IN (
-					SELECT `album_id` FROM `*PREFIX*music_tracks`
-					GROUP BY `album_id`
-				);',
-			'DELETE FROM `*PREFIX*music_album_artists` WHERE `album_id` NOT IN (
-					SELECT `id` FROM `*PREFIX*music_albums`
-					GROUP BY `id`
-				);',
-			'DELETE FROM `*PREFIX*music_artists` WHERE `id` NOT IN (
-					SELECT `artist_id` FROM `*PREFIX*music_album_artists`
-					GROUP BY `artist_id`
-				);'
+			'DELETE FROM `*PREFIX*music_albums` WHERE `id` IN (
+				SELECT `id` FROM (
+					SELECT `*PREFIX*music_albums`.`id`
+					FROM `*PREFIX*music_albums`
+					LEFT JOIN `*PREFIX*music_tracks`
+						ON `*PREFIX*music_tracks`.`album_id` = `*PREFIX*music_albums`.`id`
+					WHERE `*PREFIX*music_tracks`.`album_id` IS NULL
+				) as tmp
+			);',
+			'DELETE FROM `*PREFIX*music_album_artists` WHERE `album_id` IN (
+				SELECT `album_id` FROM (
+					SELECT `*PREFIX*music_album_artists`.`album_id`
+					FROM `*PREFIX*music_album_artists`
+					LEFT JOIN `*PREFIX*music_albums`
+						ON `*PREFIX*music_albums`.`id` = `*PREFIX*music_album_artists`.`album_id`
+					WHERE `*PREFIX*music_albums`.`id` IS NULL
+				) as tmp
+			);',
+			'DELETE FROM `*PREFIX*music_artists` WHERE `id` IN (
+				SELECT `id` FROM (
+					SELECT `*PREFIX*music_artists`.`id`
+					FROM `*PREFIX*music_artists`
+					LEFT JOIN `*PREFIX*music_album_artists`
+						ON `*PREFIX*music_album_artists`.`artist_id` = `*PREFIX*music_artists`.`id`
+					WHERE `*PREFIX*music_album_artists`.`artist_id` IS NULL
+				) as tmp
+			);',
 		);
 
 		foreach ($sqls as $sql) {


### PR DESCRIPTION
The cleanup SQL statements took about 4-5 minutes in our production environment. After changing it to use JOINs instead the queries are done in seconds.

I also added a bit more testdata, so the integration test actually has some orphaned data to delete in cleanup method. Succesfully tested with OC 8.2.2