### PR TITLE
Fix# replace deprecated findLanguage() for 9.0

### DIFF
--- a/controller/pagecontroller.php
+++ b/controller/pagecontroller.php
@@ -40,7 +40,7 @@ class PageController extends Controller {
 	 * @NoCSRFRequired
 	 */
 	public function index() {
-		$userLang = $this->l10n->findLanguage();
+		$userLang = $this->l10n->getLanguageCode();
 		return $this->render('main', array('lang' => $userLang));
 	}
 }


### PR DESCRIPTION
fix #470 