### PR TITLE
Use HTTP response codes for Ampache password API

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To use Ampache you can't use your ownCloud password. Instead, you need to genera
 Go to "Your username" → "Personal", and check section Music/Ampache, where you can generate your key. Enter your ownCloud username and the generated key as password to your client.
 
 You may use the `/settings/userkey/generate` endpoint to programatically generate a random password. The endpoint expects two parameters, `length` (optional) and `description` (mandatory) and returns a JSON response.
-Please note that the minimum password length is 10 characters.
+Please note that the minimum password length is 10 characters. The HTTP return codes represent also the status of the request.
 
 ```
 POST /settings/userkey/generate
@@ -87,31 +87,32 @@ Parameters:
 Response (success):
 
 ```
+HTTP/1.1 201 Created
+
 {
-    "success": true,
     "id": <userkey_id>,
     "password": <random_password>,
     "description": <description>
 }
 ```
 
-Response (no description provided):
+Response (error - no description provided):
 
 ```
+HTTP/1.1 400 Bad request
+
 {
-    "success": false,
     "message": "Please provide a description"
 }
 ```
 
-Response (error saving password):
+Response (error - error while saving password):
 
 ```
+HTTP/1.1 500 Internal Server Error
+
 {
-    "success": false,
-    "id": null,
-    "password": <random_password>,
-    "description": <description>
+    "message": "Error while saving the credentials"
 }
 ```
 

--- a/controller/settingcontroller.php
+++ b/controller/settingcontroller.php
@@ -13,6 +13,7 @@
 namespace OCA\Music\Controller;
 
 use \OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use \OCP\AppFramework\Http\JSONResponse;
 use \OCP\Files\Folder;
 use \OCP\IConfig;
@@ -101,10 +102,8 @@ class SettingController extends Controller {
 	 * @CORS
 	 */
 	public function generateUserKey($length, $description) {
-		$success = false;
-
 		if($description == NULL) {
-			return new JSONResponse(array('success' => $success, 'message' => $this->l10n->t('Please provide a description')));
+			return new JSONResponse(['message' => $this->l10n->t('Please provide a description')], Http::STATUS_BAD_REQUEST);
 		}
 
 		if($length == NULL || $length < self::DEFAULT_PASSWORD_LENGTH) {
@@ -118,11 +117,11 @@ class SettingController extends Controller {
 		$hash = hash('sha256', $password);
 		$id = $this->ampacheUserMapper->addUserKey($this->userId, $hash, $description);
 
-		if($id !== null) {
-			$success = true;
+		if(is_null($id)) {
+			return new JSONResponse(['message' => $this->l10n->t('Error while saving the credentials')], Http::STATUS_INTERNAL_SERVER_ERROR);
 		}
 
-		return new JSONResponse(array('success' => $success, 'id' => $id, 'password' => $password, 'description' => $description));
+		return new JSONResponse(['id' => $id, 'password' => $password, 'description' => $description], Http::STATUS_CREATED);
 	}
 
 	/**


### PR DESCRIPTION
I just switched from the success code inside the data to a HTTP return code. It's just easier to distinguish then the results ;)

Beside that: Thanks @gnarula! :)