### PR TITLE
AmpacheAPI: fix add and update timestamp in handshake endpoint

### DIFF
--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -248,6 +248,16 @@
 				<notnull>false</notnull>
 				<length>36</length>
 			</field>
+			<field>
+				<name>added</name>
+				<type>timestamp</type>
+				<notnull>true</notnull>
+			</field>
+			<field>
+				<name>updated</name>
+				<type>timestamp</type>
+				<notnull>true</notnull>
+			</field>
 
 			<index>
 				<name>music_tracks_artist_id_idx</name>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>Music player and server for ownCloud</description>
 	<licence>AGPLv3</licence>
 	<author>Morris Jobke, Jan-Christoph Borchardt (design)</author>
-	<version>0.3.12</version>
+	<version>0.3.13</version>
 	<dependencies>
 		<owncloud min-version="7.0" max-version="9.1" />
 	</dependencies>

--- a/businesslayer/trackbusinesslayer.php
+++ b/businesslayer/trackbusinesslayer.php
@@ -36,6 +36,8 @@ use \OCA\Music\Db\Track;
 
 class TrackBusinessLayer extends BusinessLayer {
 
+	const DATE_FORMAT = 'Y-m-d H:i:s';
+
 	private $logger;
 
 	public function __construct(TrackMapper $trackMapper, Logger $logger){
@@ -88,6 +90,7 @@ class TrackBusinessLayer extends BusinessLayer {
 	 * @throws \OCA\Music\AppFramework\BusinessLayer\BusinessLayerException
 	 */
 	public function addTrackIfNotExist($title, $number, $artistId, $albumId, $fileId, $mimetype, $userId, $length=null, $bitrate=null){
+		$date = new \DateTime();
 		try {
 			$track = $this->mapper->findByFileId($fileId, $userId);
 			$track->setTitle($title);
@@ -96,10 +99,11 @@ class TrackBusinessLayer extends BusinessLayer {
 			$track->setAlbumId($albumId);
 			$track->setMimetype($mimetype);
 			$track->setUserId($userId);
-			$this->mapper->update($track);
 			$track->setLength($length);
 			$track->setBitrate($bitrate);
-			$this->logger->log('addTrackIfNotExist - exists & updated - ID: ' . $track->getId(), 'debug');
+			$track->setUpdated($date->format(self::DATE_FORMAT));
+			$this->mapper->update($track);
+			$this->logger->log('addTrackIfNotExist - exists & updated - ID: ' . $track->getId() . ' updated = '. $date->format(self::DATE_FORMAT), 'debug');
 		} catch(DoesNotExistException $ex){
 			$track = new Track();
 			$track->setTitle($title);
@@ -111,8 +115,9 @@ class TrackBusinessLayer extends BusinessLayer {
 			$track->setUserId($userId);
 			$track->setLength($length);
 			$track->setBitrate($bitrate);
+			$track->setAdded($date->format(self::DATE_FORMAT));
 			$track = $this->mapper->insert($track);
-			$this->logger->log('addTrackIfNotExist - added - ID: ' . $track->getId(), 'debug');
+			$this->logger->log('addTrackIfNotExist - added - ID: ' . $track->getId() . ' added = '. $date->format(self::DATE_FORMAT), 'debug');
 		} catch(MultipleObjectsReturnedException $ex){
 			throw new BusinessLayerException($ex->getMessage());
 		}

--- a/controller/ampachecontroller.php
+++ b/controller/ampachecontroller.php
@@ -183,6 +183,9 @@ class AmpacheController extends Controller {
 		$artistCount = $this->artistMapper->count($userId);
 		$albumCount = $this->albumMapper->count($userId);
 		$trackCount = $this->trackMapper->count($userId);
+		$lastChange = $this->trackMapper->lastChange($userId);
+		$lastUpdated = new \DateTime($lastChange['last_updated']);
+		$lastAdded = new \DateTime($lastChange['last_added']);
 
 		return $this->render(
 			'ampache/handshake',
@@ -192,9 +195,9 @@ class AmpacheController extends Controller {
 				'artistCount' => $artistCount,
 				'albumCount' => $albumCount,
 				'playlistCount' => 0,
-				'updateDate' => $currentTime,
+				'updateDate' => max($lastUpdated, $lastAdded)->format('c'),
 				'cleanDate' => $currentTime,
-				'addDate' => $currentTime,
+				'addDate' => $lastAdded->format('c'),
 				'expireDate' => $expiryDate
 			),
 			'blank',

--- a/db/track.php
+++ b/db/track.php
@@ -39,6 +39,12 @@ use \OCP\AppFramework\Db\Entity;
  * @method setMimetype(string $mimetype)
  * @method string getUserId()
  * @method setUserId(string $userId)
+ * @method string getMbid()
+ * @method setMbid(string $mbid)
+ * @method string getAdded()
+ * @method setAdded(string $date)
+ * @method string getUpdated()
+ * @method setUpdated(string $date)
  */
 class Track extends Entity {
 
@@ -55,6 +61,8 @@ class Track extends Entity {
 	public $mimetype;
 	public $userId;
 	public $mbid;
+	public $added;
+	public $updated;
 
 	public function __construct(){
 		$this->addType('number', 'int');

--- a/db/trackmapper.php
+++ b/db/trackmapper.php
@@ -28,7 +28,8 @@ class TrackMapper extends Mapper {
 		return 'SELECT `track`.`title`, `track`.`number`, `track`.`id`, '.
 			'`track`.`artist_id`, `track`.`album_id`, `track`.`length`, '.
 			'`track`.`file_id`, `track`.`bitrate`, `track`.`mimetype`, '.
-			'`track`.`mbid` FROM `*PREFIX*music_tracks` `track` '.
+			'`track`.`mbid`, `track`.`added`, `track`.`updated` '.
+			'FROM `*PREFIX*music_tracks` `track` '.
 			'WHERE ' . $condition;
 	}
 
@@ -185,5 +186,18 @@ class TrackMapper extends Mapper {
 		$name = '%' . $name . '%';
 		$params = array($userId, $name, $name, $name);
 		return $this->findEntities($sql, $params);
+	}
+
+	/**
+	 * @param string $userId
+	 * @return string[]
+	 */
+	public function lastChange($userId){
+		$sql = 'SELECT MAX(added) last_added, MAX(updated) last_updated FROM `*PREFIX*music_tracks` '.
+			'WHERE `user_id` = ?';
+		$params = array($userId);
+		$result = $this->execute($sql, $params);
+		$row = $result->fetch();
+		return $row;
 	}
 }

--- a/templates/ampache/handshake.php
+++ b/templates/ampache/handshake.php
@@ -4,8 +4,8 @@ print '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 <root>
 	<auth><?php p($_['token']);?></auth>
 	<version>350001</version>
-	<update><?php p(date('c', $_['updateDate']));?></update>
-	<add><?php p(date('c', $_['addDate']));?></add>
+	<update><?php p($_['updateDate']);?></update>
+	<add><?php p($_['addDate']);?></add>
 	<clean><?php p(date('c', $_['cleanDate']));?></clean>
 	<songs><?php p($_['songCount']);?></songs>
 	<artists><?php p($_['artistCount']);?></artists>


### PR DESCRIPTION
The music_tracks table now stores the time at which a track was
added and updated in the music app

update tag in the handshake endpoint contains the max of added
and updated column whichever is the latest. add tag in the handshake
endpoint contains the max of added column
