### PR TITLE
Fix on the disc number extraction

### DIFF
--- a/utility/scanner.php
+++ b/utility/scanner.php
@@ -239,6 +239,8 @@ class Scanner extends PublicEmitter {
 			$discNumber = "1";
 			if($hasComments && array_key_exists('discnumber', $fileInfo['comments'])){
 				$discNumber = $fileInfo['comments']['discnumber'][0];
+			} else if($hasComments && array_key_exists('part_of_a_set', $fileInfo['comments'])){
+				$discNumber = $fileInfo['comments']['part_of_a_set'][0];
 			}
 			// convert disc number '1/10' to '1'
 			$tmp = explode('/', $discNumber);


### PR DESCRIPTION
The code in scanner.php tried to extract the disc number from track using the key 'discnumber'. However, at least with my MP3 files the disc number is actually found with key 'part_of_a_set'. Hence, all tracks were added to the database with disc number 1.

I modified the scanner.php to accept both 'discnumber' and 'part_of_a_set'. But actually, looking at the sources of getID3, I believe that the key 'discnumber' will never work.