### PR TITLE
Fixes on small UI glitches

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -32,11 +32,15 @@
 }
 
 .play {
-	display: none;
+	display: inline;
+	visibility: hidden;
 	/* opacity */
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=70)";
 	filter: alpha(opacity = 70);
 	opacity: .7;
+	height: 10px;
+	margin-left: 0px;
+	margin-right: 6px;
 }
 
 .artist-area {
@@ -81,7 +85,7 @@
 	display: inline-block;
 }
 
-.album-area > h2:hover {
+.album-area > h2 *:hover {
 	cursor: pointer;
 }
 
@@ -106,7 +110,7 @@
 }
 
 .album-area:hover > img.overlay {
-	display: inline;
+	visibility: visible;
 	cursor: pointer;
 }
 
@@ -115,23 +119,24 @@
 }
 
 .track-list > li {
-	padding-left: 21px;
+	padding-left: 2px;
 	padding-bottom: 11px;
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
 }
 
-.track-list > li:hover {
+.track-list > li:hover, li *:hover {
 	cursor: pointer;
+}
+
+.track-list > li.more-less {
+	padding-left: 21px;
 }
 
 .track-list > li > .play.playing,
 .track-list > li:hover > .play {
-	display: inline;
-	height: 10px;
-	margin-left: -19px;
-	margin-right: 6px;
+	visibility: visible;
 }
 
 .muted {

--- a/templates/partials/overview.php
+++ b/templates/partials/overview.php
@@ -41,12 +41,12 @@
 				<span ng-show="track.number" class="muted">{{ track.number }}.</span>
 				{{ track.title }}
 			</li>
-			<li class="muted" translate translate-n="trackcount"
+			<li class="muted more-less" translate translate-n="trackcount"
 				translate-plural="Show all {{ trackcount }} songs ..."
 				ng-click="limit.count = trackcount"
 				ng-hide="trackcount <= limit.count || limit.count != 5"
 				>Show all {{ trackcount }} songs ...</li>
-			<li class="muted"
+			<li class="muted more-less"
 				ng-click="limit.count = 5"
 				ng-hide="limit.count == 5" translate>Show less ...</li>
 		</ul>


### PR DESCRIPTION
This PR provides fixes for following small UI glitches:

- On Firefox, the small play icon was not visible in front of the track name while hovering/playing if the track name was truncated. Apparently, Firefox didn't tolerate the negative margin in this situation. The bug was not visible on Chrome or Edge.
- There was a tiny bit of jitter when tracks of album were hovered over. The track name moved horizontally maybe one pixel when the play icon was shown/hidden. This was visible on all browsers.
- The mouse cursor didn't correctly change to pointer icon on all clickable items like album names and the "Show all X songs..." item. This happened on all browsers.

The proper functionality of the UI was tested on up-to-date versions of Firefox, Chrome, and Edge.