### PR TITLE
Show track artist on track when it differs from the album artist

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Parameters:
 
 ```
 {
-    "length": <length>,
-    "description": <description>
+	"length": <length>,
+	"description": <description>
 }
 ```
 
@@ -90,9 +90,9 @@ Response (success):
 HTTP/1.1 201 Created
 
 {
-    "id": <userkey_id>,
-    "password": <random_password>,
-    "description": <description>
+	"id": <userkey_id>,
+	"password": <random_password>,
+	"description": <description>
 }
 ```
 
@@ -102,7 +102,7 @@ Response (error - no description provided):
 HTTP/1.1 400 Bad request
 
 {
-    "message": "Please provide a description"
+	"message": "Please provide a description"
 }
 ```
 
@@ -112,7 +112,7 @@ Response (error - error while saving password):
 HTTP/1.1 500 Internal Server Error
 
 {
-    "message": "Error while saving the credentials"
+	"message": "Error while saving the credentials"
 }
 ```
 
@@ -154,15 +154,15 @@ more to the beginning of the HTML element.
 
 PHP unit tests
 
-    phpunit --coverage-html coverage-html-unit --configuration tests/php/unit/phpunit.xml tests/php/unit
+	phpunit --coverage-html coverage-html-unit --configuration tests/php/unit/phpunit.xml tests/php/unit
 
 PHP integration tests
 
-    cd ../..          # owncloud core
-    ./occ maintenance:install --admin-user admin --admin-pass admin --database sqlite
-    ./occ app:enable music
-    cd apps/music
-    phpunit --coverage-html coverage-html-integration --configuration tests/php/integration/phpunit.xml tests/php/integration
+	cd ../..          # owncloud core
+	./occ maintenance:install --admin-user admin --admin-pass admin --database sqlite
+	./occ app:enable music
+	cd apps/music
+	phpunit --coverage-html coverage-html-integration --configuration tests/php/integration/phpunit.xml tests/php/integration
 
 Behat acceptance tests
 
@@ -233,14 +233,17 @@ Response:
 				{
 					"name": "Nightfall in Middle-Earth",
 					"year": 1998,
+					"disk" : 1,
 					"cover": "/index.php/apps/music/api/album/16/cover",
 					"id": 16,
 					"tracks": [
 						{
 							"title": "A Dark Passage",
 							"number": 21,
+							"artistName": "Blind Guardian",
 							"artistId": 2,
 							"albumId": 16,
+							"albumArtistId": 2,
 							"files": {
 								"audio/mpeg": "https://own.cloud.example.org/remote.php/webdav/Blind Guardian/1998 - Nightfall in Middle-Earth/21 - A Dark Passage.mp3"
 							},
@@ -249,8 +252,10 @@ Response:
 						{
 							"title": "Battle of Sudden Flame",
 							"number": 12,
+							"artistName": "Blind Guardian",
 							"artistId": 2,
 							"albumId": 16,
+							"albumArtistId": 2,
 							"files": {
 								"audio/mpeg": "https://own.cloud.example.org/remote.php/webdav/Blind Guardian/1998 - Nightfall in Middle-Earth/12 - Battle of Sudden Flame.mp3"
 							},
@@ -267,14 +272,17 @@ Response:
 				{
 					"name": "Stay Together for the Kids",
 					"year": 2002,
+					"disk" : 1,
 					"cover": "/index.php/apps/music/api/album/22/cover",
 					"id": 22,
 					"tracks": [
 						{
 							"title": "Stay Together for the Kids",
 							"number": 1,
+							"artistName": "blink-182",
 							"artistId": 3,
 							"albumId": 22,
+							"albumArtistId": 3,
 							"files": {
 								"audio/mpeg": "https://own.cloud.example.org/remote.php/webdav/blink-182/2002 - Stay Together for the Kids/01 - Stay Together for the Kids.mp3"
 							},
@@ -283,8 +291,10 @@ Response:
 						{
 							"title": "The Rock Show (live)",
 							"number": 2,
+							"artistName": "blink-182",
 							"artistId": 3,
 							"albumId": 22,
+							"albumArtistId": 3,
 							"files": {
 								"audio/mpeg": "https://own.cloud.example.org/remote.php/webdav/blink-182/2002 - Stay Together for the Kids/02 - The Rock Show (live).mp3"
 							},

--- a/controller/apicontroller.php
+++ b/controller/apicontroller.php
@@ -107,16 +107,19 @@ class ApiController extends Controller {
 		$artists = array();
 		foreach ($allTracks as $track) {
 			$albumObj = $this->albumBusinessLayer->find($track->getAlbumId(), $this->userId);
+			$trackArtistObj = $this->artistBusinessLayer->find($track->getArtistId(), $this->userId);
 			$track->setAlbum($albumObj);
-			$artist = &$allArtistsById[$albumObj->getAlbumArtistId()];
-			if (!isset($artist['albums'])) {
-				$artist['albums'] = array();
-				$artists[] = &$artist;
+			$track->setArtist($trackArtistObj);
+
+			$albumArtist = &$allArtistsById[$albumObj->getAlbumArtistId()];
+			if (!isset($albumArtist['albums'])) {
+				$albumArtist['albums'] = array();
+				$artists[] = &$albumArtist;
 			}
 			$album = &$allAlbumsById[$track->getAlbumId()];
 			if (!isset($album['tracks'])) {
 				$album['tracks'] = array();
-				$artist['albums'][] = &$album;
+				$albumArtist['albums'][] = &$album;
 			}
 			try {
 				$album['tracks'][] = $track->toCollection($this->urlGenerator, $this->userFolder);
@@ -287,6 +290,7 @@ class ApiController extends Controller {
 		$fileId = $this->params('fileId');
 		$track = $this->trackBusinessLayer->findByFileId($fileId, $this->userId);
 		$track->setAlbum($this->albumBusinessLayer->find($track->getAlbumId(), $this->userId));
+		$track->setArtist($this->artistBusinessLayer->find($track->getArtistId(), $this->userId));
 		return new JSONResponse($track->toCollection($this->urlGenerator, $this->userFolder));
 	}
 

--- a/controller/apicontroller.php
+++ b/controller/apicontroller.php
@@ -90,15 +90,19 @@ class ApiController extends Controller {
 	public function collection() {
 		/** @var Artist[] $allArtists */
 		$allArtists = $this->artistBusinessLayer->findAll($this->userId);
-		$allArtistsById = array();
+		$allArtistsByIdAsObj = array();
+		$allArtistsByIdAsArr = array();
 		foreach ($allArtists as &$artist) {
-			$allArtistsById[$artist->getId()] = $artist->toCollection($this->l10n);
+			$allArtistsByIdAsObj[$artist->getId()] = $artist;
+			$allArtistsByIdAsArr[$artist->getId()] = $artist->toCollection($this->l10n);
 		}
 
 		$allAlbums = $this->albumBusinessLayer->findAll($this->userId);
-		$allAlbumsById = array();
+		$allAlbumsByIdAsObj = array();
+		$allAlbumsByIdAsArr = array();
 		foreach ($allAlbums as &$album) {
-			$allAlbumsById[$album->getId()] = $album->toCollection($this->urlGenerator, $this->l10n);
+			$allAlbumsByIdAsObj[$album->getId()] = $album;
+			$allAlbumsByIdAsArr[$album->getId()] = $album->toCollection($this->urlGenerator, $this->l10n);
 		}
 
 		/** @var Track[] $allTracks */
@@ -106,17 +110,17 @@ class ApiController extends Controller {
 
 		$artists = array();
 		foreach ($allTracks as $track) {
-			$albumObj = $this->albumBusinessLayer->find($track->getAlbumId(), $this->userId);
-			$trackArtistObj = $this->artistBusinessLayer->find($track->getArtistId(), $this->userId);
+			$albumObj = $allAlbumsByIdAsObj[$track->getAlbumId()];
+			$trackArtistObj = $allArtistsByIdAsObj[$track->getArtistId()];
 			$track->setAlbum($albumObj);
 			$track->setArtist($trackArtistObj);
 
-			$albumArtist = &$allArtistsById[$albumObj->getAlbumArtistId()];
+			$albumArtist = &$allArtistsByIdAsArr[$albumObj->getAlbumArtistId()];
 			if (!isset($albumArtist['albums'])) {
 				$albumArtist['albums'] = array();
 				$artists[] = &$albumArtist;
 			}
-			$album = &$allAlbumsById[$track->getAlbumId()];
+			$album = &$allAlbumsByIdAsArr[$track->getAlbumId()];
 			if (!isset($album['tracks'])) {
 				$album['tracks'] = array();
 				$albumArtist['albums'][] = &$album;

--- a/db/track.php
+++ b/db/track.php
@@ -107,6 +107,7 @@ class Track extends Entity {
 		return array(
 			'title' => $this->getTitle(),
 			'number' => $this->getNumber(),
+			'artistName' => $this->getArtist()->getName(),
 			'artistId' => $this->getArtistId(),
 			'albumId' => $this->getAlbumId(),
 			'albumArtistId' => $this->getAlbum()->getAlbumArtistId(),

--- a/templates/main.php
+++ b/templates/main.php
@@ -76,7 +76,7 @@ if($version[0] < 8 || $version[0] === 8 && $version[1] < 2) {
 
 				<div class="song-info">
 					<span class="title" title="{{ currentTrack.title }}">{{ currentTrack.title }}</span><br />
-					<span class="artist" title="{{ currentArtist.name }}">{{ currentArtist.name }}</span>
+					<span class="artist" title="{{ currentTrack.artistName }}">{{ currentTrack.artistName }}</span>
 				</div>
 				<div ng-show="currentTrack.title" class="progress-info">
 					<span ng-hide="loading" class="muted">{{ position.current | playTime }}/{{ position.total | playTime }}</span>

--- a/templates/partials/overview.php
+++ b/templates/partials/overview.php
@@ -35,11 +35,13 @@
 		<!-- variable "limit" toogles length of track list for each album -->
 		<ul class="track-list" ng-init="limit.count = 5; trackcount = album.tracks.length">
 			<li ng-click="playTrack(track)"
-				ng-repeat="track in album.tracks | orderBy:'number' | limitTo:limit.count" title="{{ track.title }}">
+				ng-repeat="track in album.tracks | orderBy:'number' | limitTo:limit.count"
+				title="{{ track.title + ((track.artistId != track.albumArtistId) ? ' // ' + track.artistName : '') }}">
 				<img class="play svg" alt="{{ 'Play' | translate }}" src="<?php p(OCP\image_path('music', 'play-big.svg')) ?>"
 					ng-class="{playing: currentTrack.id == track.id}" />
 				<span ng-show="track.number" class="muted">{{ track.number }}.</span>
 				{{ track.title }}
+				<span ng-if="track.artistId != track.albumArtistId" class="muted">// {{ track.artistName }}</span>
 			</li>
 			<li class="muted" translate translate-n="trackcount"
 				translate-plural="Show all {{ trackcount }} songs ..."

--- a/templates/partials/overview.php
+++ b/templates/partials/overview.php
@@ -36,12 +36,12 @@
 		<ul class="track-list" ng-init="limit.count = 5; trackcount = album.tracks.length">
 			<li ng-click="playTrack(track)"
 				ng-repeat="track in album.tracks | orderBy:'number' | limitTo:limit.count"
-				title="{{ track.title + ((track.artistId != track.albumArtistId) ? ' // ' + track.artistName : '') }}">
+				title="{{ track.title + ((track.artistId != track.albumArtistId) ? '  (' + track.artistName + ')' : '') }}">
 				<img class="play svg" alt="{{ 'Play' | translate }}" src="<?php p(OCP\image_path('music', 'play-big.svg')) ?>"
 					ng-class="{playing: currentTrack.id == track.id}" />
 				<span ng-show="track.number" class="muted">{{ track.number }}.</span>
 				{{ track.title }}
-				<span ng-if="track.artistId != track.albumArtistId" class="muted">// {{ track.artistName }}</span>
+				<span ng-if="track.artistId != track.albumArtistId" class="muted">&nbsp;({{ track.artistName }})</span>
 			</li>
 			<li class="muted" translate translate-n="trackcount"
 				translate-plural="Show all {{ trackcount }} songs ..."

--- a/tests/php/unit/controller/APIControllerTest.php
+++ b/tests/php/unit/controller/APIControllerTest.php
@@ -1032,6 +1032,10 @@ class APIControllerTest extends ControllerTestUtility {
 		$album->setId(1);
 		$album->setAlbumArtistId(1);
 
+		$artist = new Artist();
+		$artist->setId(3);
+		$artist->setName('The track artist');
+		
 		$this->trackBusinessLayer->expects($this->once())
 			->method('findByFileId')
 			->with($this->equalTo($fileId), $this->equalTo($this->userId))
@@ -1042,8 +1046,14 @@ class APIControllerTest extends ControllerTestUtility {
 			->with($this->equalTo($track->getAlbumId()), $this->equalTo($this->userId))
 			->will($this->returnValue($album));
 
+		$this->artistBusinessLayer->expects($this->once())
+			->method('find')
+			->with($this->equalTo($track->getArtistId()), $this->equalTo($this->userId))
+			->will($this->returnValue($artist));
+
 		$result = array(
 			'title' => 'The title',
+			'artistName' => 'The track artist',
 			'id' => 1,
 			'number' => 4,
 			'artistId' => 3,


### PR DESCRIPTION
The Music app had such a shortcoming that the track artist could not be seen from anywhere. Only the album artist was visible.

This PR addresses the issue by adding the track artist name after the track name in case the track artist and album artist are not the same. In addition, the track artist name is shown in the top pane for the currently playing song instead of the album artist. The albums are grouped by album artists and the album artist names are used as group titles like before.

![show_track_artist](https://cloud.githubusercontent.com/assets/8565946/17194943/9fbef19c-5463-11e6-9a0f-dbf60373d191.png)
