### PR TITLE
Use track artist and album artist as fallbacks for each other

### DIFF
--- a/utility/scanner.php
+++ b/utility/scanner.php
@@ -163,18 +163,24 @@ class Scanner extends PublicEmitter {
 			if($hasComments && array_key_exists('artist', $fileInfo['comments'])){
 				$artist = $fileInfo['comments']['artist'][0];
 			}
-			if($artist === '' || $artist === null){
-				// set artist to Unknown Artist
-				$artist = 'Unknown Artist';
-			}
 
 			// albumArtist
 			$albumArtist = null;
 			if($hasComments && array_key_exists('band', $fileInfo['comments'])){
 				$albumArtist = $fileInfo['comments']['band'][0];
 			}
-			if($albumArtist === '' || $albumArtist === null){
-				// set albumArtist to Unknown Artist
+
+			// use artist and albumArtist as fallbacks for each other
+			if($this->isNullOrEmpty($albumArtist)){
+				$albumArtist = $artist;
+			}
+			if($this->isNullOrEmpty($artist)){
+				$artist = $albumArtist;
+			}
+
+			// set 'Unknown Artist' in case neither artist nor albumArtist was found
+			if($this->isNullOrEmpty($artist)){
+				$artist = 'Unknown Artist';
 				$albumArtist = 'Unknown Artist';
 			}
 
@@ -184,7 +190,7 @@ class Scanner extends PublicEmitter {
 			if($hasComments && array_key_exists('title', $fileInfo['comments'])){
 				$title = $fileInfo['comments']['title'][0];
 			}
-			if($title === null || $title === ''){
+			if($this->isNullOrEmpty($title)){
 				// fallback to file name
 				$title = $file->getName();
 				if(preg_match('/^(\d+)\W*[.-]\W*(.*)/', $title, $matches) === 1) {
@@ -202,7 +208,7 @@ class Scanner extends PublicEmitter {
 			if($hasComments && array_key_exists('album', $fileInfo['comments'])){
 				$album = $fileInfo['comments']['album'][0];
 			}
-			if($album === '' || $album === null){
+			if($this->isNullOrEmpty($album)){
 				// album name not set in fileinfo, use parent folder name as album name
 				if ( $this->userFolder->getId() === $file->getParent()->getId() ) {
 					// if the file is in user home, still set album name to unknown
@@ -477,5 +483,9 @@ class Scanner extends PublicEmitter {
 		}
 
 		$this->db->executeUpdate('DELETE FROM `*PREFIX*music_album_artists` WHERE `album_id` NOT IN (SELECT `id` FROM `*PREFIX*music_albums` GROUP BY `id`);');
+	}
+
+	private static function isNullOrEmpty($string) {
+		return $string === null || $string === '';
 	}
 }


### PR DESCRIPTION
In the current main branch implementation, all albums without the 'album artist' tag set are listed under 'Unknown Artist'. My own music library, for example, contains dozens of such albums. I have used the 'album artist' tag mostly in cases where the album artist and track artist actually differ. For the rest of the tracks, I haven't bothered since it makes no difference in majority of the music players I have used. I believe I'm not the only one with the same situation.

In this PR, I have mitigated the problem by adding the following fallback logic:
- If the music file has no 'album artist' tag, the album artist is assumed to be the same as track artist
- If the music file has no 'artist' tag, the track artist is assumed to be the same as the album artist
- If neither 'artist' nor 'album artist' tag is available, then both artist and album artist are set to 'Unknown Artist'

The logic is applied at the library scanning time. Hence, the music database has to be regenerated to benefit from the change.

The logic is heuristic, of course, and may not create perfect result in all cases. However, I believe that this is more in line with the user expectations in majority of cases than substituting 'Unknown Artist' for all missing artist fields.