### PR TITLE
Fixed automatic starting of music playback via a link + scroll to the started album

### DIFF
--- a/js/app/controllers/maincontroller.js
+++ b/js/app/controllers/maincontroller.js
@@ -9,8 +9,8 @@
  */
 
 angular.module('Music').controller('MainController',
-	['$rootScope', '$scope', '$route', 'ArtistFactory', 'playlistService', 'gettextCatalog', 'Restangular',
-	function ($rootScope, $scope, $route, ArtistFactory, playlistService, gettextCatalog, Restangular) {
+	['$rootScope', '$scope', '$route', '$timeout', 'ArtistFactory', 'playlistService', 'gettextCatalog', 'Restangular',
+	function ($rootScope, $scope, $route, $timeout, ArtistFactory, playlistService, gettextCatalog, Restangular) {
 
 	// retrieve language from backend - is set in ng-app HTML element
 	gettextCatalog.currentLanguage = $rootScope.lang;
@@ -67,7 +67,11 @@ angular.module('Music').controller('MainController',
 
 			}
 
-			$rootScope.$emit('artistsLoaded');
+			// Emit the event asynchronously so that the DOM tree has already been
+			// manipulated and rendered by the browser when obeservers get the event.
+			$timeout(function() {
+				$rootScope.$emit('artistsLoaded');
+			});
 		});
 	};
 

--- a/js/app/controllers/overviewcontroller.js
+++ b/js/app/controllers/overviewcontroller.js
@@ -109,26 +109,8 @@ angular.module('Music').controller('OverviewController',
 			window.location.hash = '#/';
 		});
 
-		// variable to count events which needs triggered first to successfully process the request
-		$scope.eventsBeforePlaying = 2;
-
-		// will be invoked by the audio factory
-		$rootScope.$on('SoundManagerReady', function() {
-			if($rootScope.started) {
-				// invoke play after the flash gets unblocked
-				$scope.$apply(function(){
-					playlistService.publish('play');
-				});
-			}
-			if (!--$scope.eventsBeforePlaying) {
-				$scope.initializePlayerStateFromURL();
-			}
-		});
-
 		$rootScope.$on('artistsLoaded', function () {
-			if (!--$scope.eventsBeforePlaying) {
-				$scope.initializePlayerStateFromURL();
-			}
+			$scope.initializePlayerStateFromURL();
 		});
 
 		$scope.initializePlayerStateFromURL = function() {

--- a/js/app/controllers/overviewcontroller.js
+++ b/js/app/controllers/overviewcontroller.js
@@ -9,8 +9,8 @@
  */
 
 angular.module('Music').controller('OverviewController',
-	['$scope', '$rootScope', 'playlistService', 'Restangular', '$route',
-	function ($scope, $rootScope, playlistService, Restangular, $route) {
+	['$scope', '$rootScope', 'playlistService', 'Restangular', '$route', '$window',
+	function ($scope, $rootScope, playlistService, Restangular, $route, $window) {
 
 		// Prevent controller reload when the URL is updated with window.location.hash.
 		// See http://stackoverflow.com/a/12429133/2104976
@@ -99,6 +99,7 @@ angular.module('Music').controller('OverviewController',
 					.then(function(result){
 						playlistService.setPlaylist([result]);
 						playlistService.publish('play');
+						$scope.scrollToItem('album-' + result.albumId);
 					});
 			}
 		};
@@ -108,6 +109,13 @@ angular.module('Music').controller('OverviewController',
 			// update URL hash
 			window.location.hash = '#/';
 		});
+
+		$scope.scrollToItem = function(itemId) {
+			var el = $window.document.getElementById(itemId);
+			if(el) {
+				el.scrollIntoView({behavior: "smooth"});
+			}
+		};
 
 		$rootScope.$on('artistsLoaded', function () {
 			$scope.initializePlayerStateFromURL();
@@ -129,6 +137,7 @@ angular.module('Music').controller('OverviewController',
 					});
 					// trigger play
 					$scope.playArtist(object);
+					$scope.scrollToItem('artist-' + object.id);
 				} else {
 					var albums = _.flatten(_.pluck($scope.$parent.artists, 'albums'));
 					if (type == 'album') {
@@ -138,6 +147,7 @@ angular.module('Music').controller('OverviewController',
 						});
 						// trigger play
 						$scope.playAlbum(object);
+						$scope.scrollToItem('album-' + object.id);
 					} else if (type == 'track') {
 						var tracks = _.flatten(_.pluck(albums, 'tracks'));
 						// search for the track by id
@@ -146,9 +156,9 @@ angular.module('Music').controller('OverviewController',
 						});
 						// trigger play
 						$scope.playTrack(object);
+						$scope.scrollToItem('album-' + object.albumId);
 					}
 				}
 			}
 		};
-
 }]);

--- a/js/app/controllers/overviewcontroller.js
+++ b/js/app/controllers/overviewcontroller.js
@@ -117,6 +117,10 @@ angular.module('Music').controller('OverviewController',
 			}
 		};
 
+		$rootScope.$on('requestScrollToAlbum', function(event, albumId) {
+			$scope.scrollToItem('album-' + albumId);
+		});
+
 		$rootScope.$on('artistsLoaded', function () {
 			$scope.initializePlayerStateFromURL();
 		});

--- a/js/app/controllers/playercontroller.js
+++ b/js/app/controllers/playercontroller.js
@@ -194,4 +194,10 @@ angular.module('Music').controller('PlayerController',
 		// fetch track and start playing
 		$scope.next();
 	});
+
+	$scope.scrollToCurrentAlbum = function() {
+		if ($scope.currentAlbum) {
+			$rootScope.$emit('requestScrollToAlbum', $scope.currentAlbum.id);
+		}
+	};
 }]);

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -255,26 +255,8 @@ angular.module('Music').controller('OverviewController',
 			window.location.hash = '#/';
 		});
 
-		// variable to count events which needs triggered first to successfully process the request
-		$scope.eventsBeforePlaying = 2;
-
-		// will be invoked by the audio factory
-		$rootScope.$on('SoundManagerReady', function() {
-			if($rootScope.started) {
-				// invoke play after the flash gets unblocked
-				$scope.$apply(function(){
-					playlistService.publish('play');
-				});
-			}
-			if (!--$scope.eventsBeforePlaying) {
-				$scope.initializePlayerStateFromURL();
-			}
-		});
-
 		$rootScope.$on('artistsLoaded', function () {
-			if (!--$scope.eventsBeforePlaying) {
-				$scope.initializePlayerStateFromURL();
-			}
+			$scope.initializePlayerStateFromURL();
 		});
 
 		$scope.initializePlayerStateFromURL = function() {

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -40,8 +40,8 @@ angular.module('Music', ['restangular', 'gettext', 'ngRoute', 'ngQueue'])
 	]);
 
 angular.module('Music').controller('MainController',
-	['$rootScope', '$scope', '$route', 'ArtistFactory', 'playlistService', 'gettextCatalog', 'Restangular',
-	function ($rootScope, $scope, $route, ArtistFactory, playlistService, gettextCatalog, Restangular) {
+	['$rootScope', '$scope', '$route', '$timeout', 'ArtistFactory', 'playlistService', 'gettextCatalog', 'Restangular',
+	function ($rootScope, $scope, $route, $timeout, ArtistFactory, playlistService, gettextCatalog, Restangular) {
 
 	// retrieve language from backend - is set in ng-app HTML element
 	gettextCatalog.currentLanguage = $rootScope.lang;
@@ -98,7 +98,11 @@ angular.module('Music').controller('MainController',
 
 			}
 
-			$rootScope.$emit('artistsLoaded');
+			// Emit the event asynchronously so that the DOM tree has already been
+			// manipulated and rendered by the browser when obeservers get the event.
+			$timeout(function() {
+				$rootScope.$emit('artistsLoaded');
+			});
 		});
 	};
 
@@ -155,8 +159,8 @@ angular.module('Music').controller('MainController',
 }]);
 
 angular.module('Music').controller('OverviewController',
-	['$scope', '$rootScope', 'playlistService', 'Restangular', '$route',
-	function ($scope, $rootScope, playlistService, Restangular, $route) {
+	['$scope', '$rootScope', 'playlistService', 'Restangular', '$route', '$window',
+	function ($scope, $rootScope, playlistService, Restangular, $route, $window) {
 
 		// Prevent controller reload when the URL is updated with window.location.hash.
 		// See http://stackoverflow.com/a/12429133/2104976
@@ -245,6 +249,7 @@ angular.module('Music').controller('OverviewController',
 					.then(function(result){
 						playlistService.setPlaylist([result]);
 						playlistService.publish('play');
+						$scope.scrollToItem('album-' + result.albumId);
 					});
 			}
 		};
@@ -254,6 +259,13 @@ angular.module('Music').controller('OverviewController',
 			// update URL hash
 			window.location.hash = '#/';
 		});
+
+		$scope.scrollToItem = function(itemId) {
+			var el = $window.document.getElementById(itemId);
+			if(el) {
+				el.scrollIntoView({behavior: "smooth"});
+			}
+		};
 
 		$rootScope.$on('artistsLoaded', function () {
 			$scope.initializePlayerStateFromURL();
@@ -275,6 +287,7 @@ angular.module('Music').controller('OverviewController',
 					});
 					// trigger play
 					$scope.playArtist(object);
+					$scope.scrollToItem('artist-' + object.id);
 				} else {
 					var albums = _.flatten(_.pluck($scope.$parent.artists, 'albums'));
 					if (type == 'album') {
@@ -284,6 +297,7 @@ angular.module('Music').controller('OverviewController',
 						});
 						// trigger play
 						$scope.playAlbum(object);
+						$scope.scrollToItem('album-' + object.id);
 					} else if (type == 'track') {
 						var tracks = _.flatten(_.pluck(albums, 'tracks'));
 						// search for the track by id
@@ -292,11 +306,11 @@ angular.module('Music').controller('OverviewController',
 						});
 						// trigger play
 						$scope.playTrack(object);
+						$scope.scrollToItem('album-' + object.albumId);
 					}
 				}
 			}
 		};
-
 }]);
 
 angular.module('Music').controller('PlayerController',

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -267,6 +267,10 @@ angular.module('Music').controller('OverviewController',
 			}
 		};
 
+		$rootScope.$on('requestScrollToAlbum', function(event, albumId) {
+			$scope.scrollToItem('album-' + albumId);
+		});
+
 		$rootScope.$on('artistsLoaded', function () {
 			$scope.initializePlayerStateFromURL();
 		});
@@ -487,6 +491,12 @@ angular.module('Music').controller('PlayerController',
 		// fetch track and start playing
 		$scope.next();
 	});
+
+	$scope.scrollToCurrentAlbum = function() {
+		if ($scope.currentAlbum) {
+			$rootScope.$emit('requestScrollToAlbum', $scope.currentAlbum.id);
+		}
+	};
 }]);
 
 angular.module('Music').controller('PlaylistController',

--- a/templates/main.php
+++ b/templates/main.php
@@ -72,10 +72,11 @@ if($version[0] < 8 || $version[0] === 8 && $version[1] < 2) {
 				</div>
 
 
-				<div ng-show="currentAlbum" class="albumart" cover="{{ currentAlbum.cover }}"
+				<div ng-show="currentAlbum" ng-click="scrollToCurrentAlbum()"
+					class="albumart clickable" cover="{{ currentAlbum.cover }}"
 					albumart="{{ currentAlbum.name }}" title="{{ currentAlbum.name }}" ></div>
 
-				<div class="song-info">
+				<div class="song-info clickable" ng-click="scrollToCurrentAlbum()">
 					<span class="title" title="{{ currentTrack.title }}">{{ currentTrack.title }}</span><br />
 					<span class="artist" title="{{ currentTrack.artistName }}">{{ currentTrack.artistName }}</span>
 				</div>

--- a/templates/partials/overview.php
+++ b/templates/partials/overview.php
@@ -23,10 +23,10 @@
 
 <div class="artist-area" ng-repeat="artist in artists | orderBy:'name'" ng-init="letter = artist.name.substr(0,1).toUpperCase()">
 	<span id="{{ letter }}" ng-show="letterAvailable[letter]"></span> <!-- TODO: use ng-if - introduced in 1.1.5 -->
-	<h1 ng-click="playArtist(artist)">{{ artist.name }} <img class="play svg" alt="{{ 'Play' | translate }}"
+	<h1 id="{{ 'artist-' + artist.id }}" ng-click="playArtist(artist)">{{ artist.name }} <img class="play svg" alt="{{ 'Play' | translate }}"
 		src="<?php p(OCP\image_path('music', 'play-big.svg')) ?>" /></h1>
 	<div class="album-area" ng-repeat="album in artist.albums | orderBy:['name', 'disk']">
-		<h2 ng-click="playAlbum(album)" title="{{ album.name }} ({{ album.year}})"><div>{{ album.name }}
+		<h2 id="{{ 'album-' + album.id }}" ng-click="playAlbum(album)" title="{{ album.name }} ({{ album.year }})"><div>{{ album.name }}
 			<span ng-show="album.year" class="muted">({{ album.year }})</span></div>
 		</h2>
 		<div ng-click="playAlbum(album)" class="albumart" cover="{{ album.cover }}" albumart="{{ album.name }}"></div>
@@ -34,7 +34,8 @@
 			src="<?php p(OCP\image_path('music', 'play-big.svg')) ?>" />
 		<!-- variable "limit" toogles length of track list for each album -->
 		<ul class="track-list" ng-init="limit.count = 5; trackcount = album.tracks.length">
-			<li ng-click="playTrack(track)"
+			<li id="{{ 'track-' + track.id }}" 
+				ng-click="playTrack(track)"
 				ng-repeat="track in album.tracks | orderBy:'number' | limitTo:limit.count"
 				title="{{ track.title + ((track.artistId != track.albumArtistId) ? '  (' + track.artistName + ')' : '') }}">
 				<img class="play svg" alt="{{ 'Play' | translate }}" src="<?php p(OCP\image_path('music', 'play-big.svg')) ?>"


### PR DESCRIPTION
Looking at the source codes, it was clear that music playback was supposed to start automatically when the Music app was entered by clicking a music file in the Files app. Similarly, playback was supposed to start if an URL like <server>/owncloud/index.php/apps/music/#/album/123 was entered. Neither of these features worked with the latest SW versions and I believe they have not worked for quite some time. These features are fixed with this PR.

In addition, the automatic playback is enhanced by also scrolling the view automatically to the album which began to play via a link.

As a third change, the currently playing album can now be scrolled to view by clicking the album art or song info in the controls pane. This is the feature requested in #365.

There is such a small annoyance, that when an album is scrolled to view, the title of the album and the first track is actually left under the controls pane. Similar issue is visible when scrolling with the artist name initials next to the scroll bar. It should be possible to fix this by scrolling with an offset but I couldn't make it work with short prototyping. I may return to it later. On the other hand, it might make sense to slightly change the design of the controls pane to get rid of these scrolling issues as well as the top of the scroll bar being hidden by the pane.