### PR TITLE
Fixed resizing of albumart placeholders when style changes (mobile/desktop)

### DIFF
--- a/js/app/directives/albumart.js
+++ b/js/app/directives/albumart.js
@@ -43,9 +43,12 @@ angular.module('Music').directive('albumart', ['$http', '$queueFactory', functio
 			element.css('background-image', '');
 			// add placeholder stuff
 			element.imageplaceholder(text);
-			// remove style of the placeholder to allow mobile styling
+			// remove inlined size-related style properties set by imageplaceholder() to allow
+			// dynamic changing between mobile and desktop styles when window size changes
 			element.css('line-height', '');
 			element.css('font-size', '');
+			element.css('width', '');
+			element.css('height', '');
 		}
 	}
 

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -524,9 +524,12 @@ angular.module('Music').directive('albumart', ['$http', '$queueFactory', functio
 			element.css('background-image', '');
 			// add placeholder stuff
 			element.imageplaceholder(text);
-			// remove style of the placeholder to allow mobile styling
+			// remove inlined size-related style properties set by imageplaceholder() to allow
+			// dynamic changing between mobile and desktop styles when window size changes
 			element.css('line-height', '');
 			element.css('font-size', '');
+			element.css('width', '');
+			element.css('height', '');
 		}
 	}
 


### PR DESCRIPTION
- The album art placeholders were not resized correctly when the style sheet used got changed on window size change. The font size and the vertical alignment of the letter changed but the colored background retained its previous size.
- This bug seems to be originated from changed behavior of the imageplaceholder() function in the core by commit 6248bad0f7. This commit is first included in Owncloud 9.0.0.