### PR TITLE
Use SoundManager2 for MP3 files when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ _Note: sometimes it might be unable to play all FLAC and MP3 files (especially i
 
 This app utilizes 2 backend players: Aurora.js and SoundManager2.
 
-Aurora.js uses Javascript and HTML5 Audio API to decode and play music, it doesn't use the browser's built-in codec. This app choose Aurora.js for FLAC and MP3 files.
+SoundManager2 utilizes the browser's built-in codec. Aurora.js uses Javascript and HTML5 Audio API to decode and play music, and it doesn't use the browser's built-in codec.
 
-SoundManager2 utilizes the browser's built-in codec, This app choose SoundManager2 for OGG files.
+This app choose SoundManager2 if the browser has a suitable codec available and Aurora.js otherwise. In practice, SoundManager is used for OGG files, Aurora.js for FLAC files, and playback backend for MP3 files varies by the browser.
 
 ## Usage hints
 

--- a/js/app/playerwrapper.js
+++ b/js/app/playerwrapper.js
@@ -62,15 +62,16 @@ PlayerWrapper.prototype.seek = function(percentage) {
 
 PlayerWrapper.prototype.fromURL = function(typeAndURL) {
 	var self = this;
-	console.log(typeAndURL['url']);
-	switch(typeAndURL['type']) {
-		case 'audio/ogg':
-			this.underlyingPlayer = 'sm2';
-			break;
-		default:
-			this.underlyingPlayer = 'aurora';
-			break;
+	var url = typeAndURL['url'];
+	var type = typeAndURL['type'];
+
+	if (soundManager.canPlayURL(url)) {
+		this.underlyingPlayer = 'sm2';
+	} else {
+		this.underlyingPlayer = 'aurora';
 	}
+	console.log('Using ' + this.underlyingPlayer + ' for type ' + type + ' URL ' + url);
+
 	switch(this.underlyingPlayer) {
 		case 'sm2':
 			this.sm2 = soundManager.setup({
@@ -79,7 +80,7 @@ PlayerWrapper.prototype.fromURL = function(typeAndURL) {
 			this.sm2.html5Only = true;
 			this.sm2.createSound({
 				id: 'ownCloudSound',
-				url: typeAndURL['url'],
+				url: url,
 				whileplaying: function() {
 					self.trigger('progress', this.position);
 				},
@@ -101,7 +102,7 @@ PlayerWrapper.prototype.fromURL = function(typeAndURL) {
 			});
 			break;
 		case 'aurora':
-			this.aurora = AV.Player.fromURL(typeAndURL['url']);
+			this.aurora = AV.Player.fromURL(url);
 			this.aurora.asset.source.chunkSize=524288;
 
 			this.aurora.on('buffer', function(percent) {


### PR DESCRIPTION
As discussed in #533, Aurora.js has some pretty bad problems playing MP3 files. We can get rid of these issues by playing MP3 files with SoundManager2 instead. The only problem is that SoundManager2 cannot play MP3 files on all browsers (Chromium) because of a missing built-in decoder.

With this PR, the logic for selecting the playback engine is altered so that PlayerWrapper asks the SoundManager2 library if it can handle the file in question. The result depends on the decoders available. If SM2 cannot be used, then PlayerWrapper falls back to Aurora.js.

The change has been tested on Firefox, Chrome, Chromium, Android Chrome, Edge, and IE9. All of these browsers can now play MP3 files. Chromium, Edge and IE9 cannot play OGG files but that was the case also before this change. IE9 cannot play FLAC files, either.

cc @pellaeon, @gnarula