### PR TITLE
Fixed and enabled seeking with SoundManager2

### DIFF
--- a/css/style-controls.css
+++ b/css/style-controls.css
@@ -118,7 +118,6 @@
 	height: 15px;
 	width: 0%;
 	background-color: #1d2d44;
-	cursor: pointer;
 }
 
 #controls .buffer-bar {

--- a/js/app/controllers/maincontroller.js
+++ b/js/app/controllers/maincontroller.js
@@ -24,15 +24,7 @@ angular.module('Music').controller('MainController',
 
 	$scope.currentTrack = null;
 	playlistService.subscribe('playing', function(e, track){
-		// determine if already inside of an $apply or $digest
-		// see http://stackoverflow.com/a/12859093
-		if($scope.$$phase) {
-			$scope.currentTrack = track;
-		} else {
-			$scope.$apply(function(){
-				$scope.currentTrack = track;
-			});
-		}
+		$scope.currentTrack = track;
 	});
 
 	$scope.anchorArtists = [];

--- a/js/app/controllers/playercontroller.js
+++ b/js/app/controllers/playercontroller.js
@@ -35,7 +35,8 @@ angular.module('Music').controller('PlayerController',
 	$scope.repeat = false;
 	$scope.shuffle = false;
 	$scope.position = {
-		buffer: 0,
+		bufferPercent: '0%',
+		currentPercent: '0%',
 		current: 0,
 		total: 0
 	};
@@ -140,10 +141,11 @@ angular.module('Music').controller('PlayerController',
 	$scope.setTime = function(position, duration) {
 		$scope.position.current = position;
 		$scope.position.total = duration;
+		$scope.position.currentPercent = Math.round(position/duration*100) + '%';
 	};
 
 	$scope.setBufferPercentage = function(percent) {
-		$scope.position.buffer = percent;
+		$scope.position.bufferPercent = Math.round(percent) + '%';
 	};
 
 	$scope.toggle = function(forcePlay) {

--- a/js/app/controllers/playercontroller.js
+++ b/js/app/controllers/playercontroller.js
@@ -51,7 +51,7 @@ angular.module('Music').controller('PlayerController',
 	}
 
 	onPlayerEvent('buffer', function (percent) {
-		$scope.setBufferPercentage(parseInt(percent));
+		$scope.setBufferPercentage(percent);
 	});
 	onPlayerEvent('ready', function () {
 		$scope.setLoading(false);

--- a/js/app/controllers/playercontroller.js
+++ b/js/app/controllers/playercontroller.js
@@ -39,32 +39,32 @@ angular.module('Music').controller('PlayerController',
 		total: 0
 	};
 
-	$scope.player.on('buffer', function (percent) {
-		$scope.setBufferPercentage(parseInt(percent));
-		$scope.$digest();
-	});
-	$scope.player.on('ready', function () {
-		$scope.setLoading(false);
-		$scope.$digest();
-	});
-	$scope.player.on('progress', function (currentTime) {
-		$scope.setTime(currentTime/1000, $scope.player.duration/1000);
-		$scope.$digest();
-	});
-	$scope.player.on('end', function() {
-		$scope.setPlay(false);
-		$scope.$digest();
-		if($scope.$$phase) {
-			$scope.next();
-		} else {
-			$scope.$apply(function(){
-				$scope.next();
+	// Player events may fire synchronously or asynchronously. Utilize $timeout
+	// to always handle them asynchronously to run the handler within digest loop
+	// but with no nested digests loop (which causes an exception).
+	function onPlayerEvent(event, handler) {
+		$scope.player.on(event, function(arg) {
+			$timeout(function() {
+				handler(arg);
 			});
-		}
+		});
+	}
+
+	onPlayerEvent('buffer', function (percent) {
+		$scope.setBufferPercentage(parseInt(percent));
 	});
-	$scope.player.on('duration', function(msecs) {
+	onPlayerEvent('ready', function () {
+		$scope.setLoading(false);
+	});
+	onPlayerEvent('progress', function (currentTime) {
+		$scope.setTime(currentTime/1000, $scope.player.duration/1000);
+	});
+	onPlayerEvent('end', function() {
+		$scope.setPlay(false);
+		$scope.next();
+	});
+	onPlayerEvent('duration', function(msecs) {
 		$scope.setTime($scope.position.current, $scope.player.duration/1000);
-		$scope.$digest();
 	});
 
 	// display a play icon in the title if a song is playing
@@ -186,8 +186,7 @@ angular.module('Music').controller('PlayerController',
 	$scope.seek = function($event) {
 		var offsetX = $event.offsetX || $event.originalEvent.layerX,
 			percentage = offsetX / $event.currentTarget.clientWidth;
-		// disable seeking for all format because of some angular error
-		//$scope.player.seek(percentage);
+		$scope.player.seek(percentage);
 	};
 
 	playlistService.subscribe('play', function(){

--- a/js/app/controllers/playercontroller.js
+++ b/js/app/controllers/playercontroller.js
@@ -30,6 +30,7 @@ angular.module('Music').controller('PlayerController',
 	$scope.currentTrack = null;
 	$scope.currentArtist = null;
 	$scope.currentAlbum = null;
+	$scope.seekCursorType = 'default';
 
 	$scope.repeat = false;
 	$scope.shuffle = false;
@@ -113,6 +114,7 @@ angular.module('Music').controller('PlayerController',
 
 			$scope.player.fromURL($scope.getPlayableFileURL($scope.currentTrack));
 			$scope.setLoading(true);
+			$scope.seekCursorType = $scope.player.seekingSupported() ? 'pointer' : 'default';
 
 			$scope.player.play();
 

--- a/js/app/playerwrapper.js
+++ b/js/app/playerwrapper.js
@@ -48,15 +48,26 @@ PlayerWrapper.prototype.togglePlayback = function() {
 	}
 };
 
+PlayerWrapper.prototype.seekingSupported = function() {
+	// Seeking is not implemented in aurora/flac.js and does not work on all
+	// files with aurora/mp3.js. Hence, we disable seeking with aurora.
+	return this.underlyingPlayer == 'sm2';
+};
+
 PlayerWrapper.prototype.seek = function(percentage) {
-	console.log('seek to '+percentage);
-	switch(this.underlyingPlayer) {
-		case 'sm2':
-			this.sm2.setPosition('ownCloudSound', percentage * this.duration);
-			break;
-		case 'aurora':
-			this.aurora.seek(percentage * this.duration);
-			break;
+	if (this.seekingSupported()) {
+		console.log('seek to '+percentage);
+		switch(this.underlyingPlayer) {
+			case 'sm2':
+				this.sm2.setPosition('ownCloudSound', percentage * this.duration);
+				break;
+			case 'aurora':
+				this.aurora.seek(percentage * this.duration);
+				break;
+		}
+	}
+	else {
+		console.log('seeking is not supported for this file');
 	}
 };
 

--- a/js/app/playerwrapper.js
+++ b/js/app/playerwrapper.js
@@ -87,13 +87,17 @@ PlayerWrapper.prototype.fromURL = function(typeAndURL) {
 				whileloading: function() {
 					self.duration = this.durationEstimate;
 					self.trigger('duration', this.durationEstimate);
-					self.trigger('buffer', parseInt(this.bytesLoaded/this.bytesTotal)*100);
+					// The buffer may contain holes after seeking but just ignore those.
+					// Show the buffering status according the last buffered position.
+					var bufCount = this.buffered.length;
+					var bufEnd = (bufCount > 0) ? this.buffered[bufCount-1].end : 0;
+					self.trigger('buffer', bufEnd / this.durationEstimate * 100);
 				},
 				onfinish: function() {
 					self.trigger('end');
 				},
 				onload: function(success) {
-					if ( success ) {
+					if (success) {
 						self.trigger('ready');
 					} else {
 						console.log('SM2: sound load error');

--- a/js/app/playerwrapper.js
+++ b/js/app/playerwrapper.js
@@ -52,7 +52,7 @@ PlayerWrapper.prototype.seek = function(percentage) {
 	console.log('seek to '+percentage);
 	switch(this.underlyingPlayer) {
 		case 'sm2':
-			this.sm2.setPosition(percentage * this.duration);
+			this.sm2.setPosition('ownCloudSound', percentage * this.duration);
 			break;
 		case 'aurora':
 			this.aurora.seek(percentage * this.duration);
@@ -94,7 +94,7 @@ PlayerWrapper.prototype.fromURL = function(typeAndURL) {
 				},
 				onload: function(success) {
 					if ( success ) {
-					self.trigger('ready');
+						self.trigger('ready');
 					} else {
 						console.log('SM2: sound load error');
 					}

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -55,15 +55,7 @@ angular.module('Music').controller('MainController',
 
 	$scope.currentTrack = null;
 	playlistService.subscribe('playing', function(e, track){
-		// determine if already inside of an $apply or $digest
-		// see http://stackoverflow.com/a/12859093
-		if($scope.$$phase) {
-			$scope.currentTrack = track;
-		} else {
-			$scope.$apply(function(){
-				$scope.currentTrack = track;
-			});
-		}
+		$scope.currentTrack = track;
 	});
 
 	$scope.anchorArtists = [];
@@ -336,32 +328,32 @@ angular.module('Music').controller('PlayerController',
 		total: 0
 	};
 
-	$scope.player.on('buffer', function (percent) {
-		$scope.setBufferPercentage(parseInt(percent));
-		$scope.$digest();
-	});
-	$scope.player.on('ready', function () {
-		$scope.setLoading(false);
-		$scope.$digest();
-	});
-	$scope.player.on('progress', function (currentTime) {
-		$scope.setTime(currentTime/1000, $scope.player.duration/1000);
-		$scope.$digest();
-	});
-	$scope.player.on('end', function() {
-		$scope.setPlay(false);
-		$scope.$digest();
-		if($scope.$$phase) {
-			$scope.next();
-		} else {
-			$scope.$apply(function(){
-				$scope.next();
+	// Player events may fire synchronously or asynchronously. Utilize $timeout
+	// to always handle them asynchronously to run the handler within digest loop
+	// but with no nested digests loop (which causes an exception).
+	function onPlayerEvent(event, handler) {
+		$scope.player.on(event, function(arg) {
+			$timeout(function() {
+				handler(arg);
 			});
-		}
+		});
+	}
+
+	onPlayerEvent('buffer', function (percent) {
+		$scope.setBufferPercentage(parseInt(percent));
 	});
-	$scope.player.on('duration', function(msecs) {
+	onPlayerEvent('ready', function () {
+		$scope.setLoading(false);
+	});
+	onPlayerEvent('progress', function (currentTime) {
+		$scope.setTime(currentTime/1000, $scope.player.duration/1000);
+	});
+	onPlayerEvent('end', function() {
+		$scope.setPlay(false);
+		$scope.next();
+	});
+	onPlayerEvent('duration', function(msecs) {
 		$scope.setTime($scope.position.current, $scope.player.duration/1000);
-		$scope.$digest();
 	});
 
 	// display a play icon in the title if a song is playing
@@ -483,8 +475,7 @@ angular.module('Music').controller('PlayerController',
 	$scope.seek = function($event) {
 		var offsetX = $event.offsetX || $event.originalEvent.layerX,
 			percentage = offsetX / $event.currentTarget.clientWidth;
-		// disable seeking for all format because of some angular error
-		//$scope.player.seek(percentage);
+		$scope.player.seek(percentage);
 	};
 
 	playlistService.subscribe('play', function(){

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -319,6 +319,7 @@ angular.module('Music').controller('PlayerController',
 	$scope.currentTrack = null;
 	$scope.currentArtist = null;
 	$scope.currentAlbum = null;
+	$scope.seekCursorType = 'default';
 
 	$scope.repeat = false;
 	$scope.shuffle = false;
@@ -402,6 +403,7 @@ angular.module('Music').controller('PlayerController',
 
 			$scope.player.fromURL($scope.getPlayableFileURL($scope.currentTrack));
 			$scope.setLoading(true);
+			$scope.seekCursorType = $scope.player.seekingSupported() ? 'pointer' : 'default';
 
 			$scope.player.play();
 

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -324,7 +324,8 @@ angular.module('Music').controller('PlayerController',
 	$scope.repeat = false;
 	$scope.shuffle = false;
 	$scope.position = {
-		buffer: 0,
+		bufferPercent: '0%',
+		currentPercent: '0%',
 		current: 0,
 		total: 0
 	};
@@ -429,10 +430,11 @@ angular.module('Music').controller('PlayerController',
 	$scope.setTime = function(position, duration) {
 		$scope.position.current = position;
 		$scope.position.total = duration;
+		$scope.position.currentPercent = Math.round(position/duration*100) + '%';
 	};
 
 	$scope.setBufferPercentage = function(percent) {
-		$scope.position.buffer = percent;
+		$scope.position.bufferPercent = Math.round(percent) + '%';
 	};
 
 	$scope.toggle = function(forcePlay) {

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -340,7 +340,7 @@ angular.module('Music').controller('PlayerController',
 	}
 
 	onPlayerEvent('buffer', function (percent) {
-		$scope.setBufferPercentage(parseInt(percent));
+		$scope.setBufferPercentage(percent);
 	});
 	onPlayerEvent('ready', function () {
 		$scope.setLoading(false);

--- a/templates/main.php
+++ b/templates/main.php
@@ -84,9 +84,10 @@ if($version[0] < 8 || $version[0] === 8 && $version[1] < 2) {
 					<span ng-hide="loading" class="muted">{{ position.current | playTime }}/{{ position.total | playTime }}</span>
 					<span ng-show="loading" class="muted">Loading...</span>
 					<div class="progress">
-						<div class="seek-bar" ng-click="seek($event)">
-							<div class="buffer-bar" style="width: {{ position.buffer }}%"></div>
-							<div class="play-bar" ng-show="position.total" style="width: {{ position.current/position.total * 100 }}%"></div>
+						<div class="seek-bar" ng-click="seek($event)" style="cursor: {{ seekCursorType }}">
+							<div class="buffer-bar" style="width: {{ position.buffer }}%; cursor: {{ seekCursorType }}"></div>
+							<div class="play-bar" ng-show="position.total" 
+								style="width: {{ position.current/position.total * 100 }}%; cursor: {{ seekCursorType }}"></div>
 						</div>
 					</div>
 				</div>

--- a/templates/main.php
+++ b/templates/main.php
@@ -84,10 +84,10 @@ if($version[0] < 8 || $version[0] === 8 && $version[1] < 2) {
 					<span ng-hide="loading" class="muted">{{ position.current | playTime }}/{{ position.total | playTime }}</span>
 					<span ng-show="loading" class="muted">Loading...</span>
 					<div class="progress">
-						<div class="seek-bar" ng-click="seek($event)" style="cursor: {{ seekCursorType }}">
-							<div class="buffer-bar" style="width: {{ position.buffer }}%; cursor: {{ seekCursorType }}"></div>
+						<div class="seek-bar" ng-click="seek($event)" ng-style="{'cursor': seekCursorType}">
+							<div class="buffer-bar" ng-style="{'width': position.bufferPercent, 'cursor': seekCursorType}"></div>
 							<div class="play-bar" ng-show="position.total" 
-								style="width: {{ position.current/position.total * 100 }}%; cursor: {{ seekCursorType }}"></div>
+								ng-style="{'width': position.currentPercent, 'cursor': seekCursorType}"></div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
Seeking was being disabled in the Music app because of an "angular issue". Angular, however, is working as it is supposed to and the bugs were in the Music app codes. After fixing these bugs, the seeking is working fine with SoundManager2.

Aurora (or its plugins), on the other hand, seems to have issues with seeking. Seeking is working properly only on some of the MP3 files. It did not work on either of the two FLAC files I tested. Hence, I thought it is better to leave the seeking disabled with Aurora.

Also some other fixes related to the progress bar were made. See the individual commit messages for full details.