### PR TITLE
Adjust the controls bar width to not overlap with the scroll bar

### DIFF
--- a/css/style-controls.css
+++ b/css/style-controls.css
@@ -129,11 +129,11 @@
 #shuffle, #repeat {
 	position: absolute;
 	top: 0;
-	right: 8px;
+	right: 0;
 }
 
 #shuffle {
-	right: 65px;
+	right: 55px;
 }
 
 #controls .active {
@@ -144,7 +144,7 @@
 
 #controls .volume-control {
 	position: absolute;
-	right: 185px;
+	right: 172px;
 }
 
 .ie.lte9 #controls .volume-control {

--- a/css/tablet.css
+++ b/css/tablet.css
@@ -40,14 +40,6 @@
 	right: 150px;
 }
 
-#controls #shuffle {
-	right: 57px;
-}
-
-#controls .volume-control {
-	right: 170px;
-}
-
 #controls #volume-icon {
 	display: none;
 }

--- a/js/app/controllers/maincontroller.js
+++ b/js/app/controllers/maincontroller.js
@@ -9,8 +9,8 @@
  */
 
 angular.module('Music').controller('MainController',
-	['$rootScope', '$scope', '$route', '$timeout', 'ArtistFactory', 'playlistService', 'gettextCatalog', 'Restangular',
-	function ($rootScope, $scope, $route, $timeout, ArtistFactory, playlistService, gettextCatalog, Restangular) {
+	['$rootScope', '$scope', '$route', '$timeout', '$window', 'ArtistFactory', 'playlistService', 'gettextCatalog', 'Restangular',
+	function ($rootScope, $scope, $route, $timeout, $window, ArtistFactory, playlistService, gettextCatalog, Restangular) {
 
 	// retrieve language from backend - is set in ng-app HTML element
 	gettextCatalog.currentLanguage = $rootScope.lang;
@@ -109,6 +109,20 @@ angular.module('Music').controller('MainController',
 			}
 		});
 	};
+
+	// adjust controls bar width to not overlap with the scroll bar
+	function adjustControlsBarWidth() {
+		try {
+			var controlsWidth = $window.innerWidth - getScrollBarWidth();
+			$('#controls').css('width', controlsWidth);
+			$('#controls').css('min-width', controlsWidth);
+		}
+		catch (exception) {
+			console.log("No getScrollBarWidth() in core");
+		}
+	}
+	$($window).resize(adjustControlsBarWidth);
+	adjustControlsBarWidth();
 
 	// initial lookup if new files are available
 	$scope.processNextScanStep(1);

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -40,8 +40,8 @@ angular.module('Music', ['restangular', 'gettext', 'ngRoute', 'ngQueue'])
 	]);
 
 angular.module('Music').controller('MainController',
-	['$rootScope', '$scope', '$route', '$timeout', 'ArtistFactory', 'playlistService', 'gettextCatalog', 'Restangular',
-	function ($rootScope, $scope, $route, $timeout, ArtistFactory, playlistService, gettextCatalog, Restangular) {
+	['$rootScope', '$scope', '$route', '$timeout', '$window', 'ArtistFactory', 'playlistService', 'gettextCatalog', 'Restangular',
+	function ($rootScope, $scope, $route, $timeout, $window, ArtistFactory, playlistService, gettextCatalog, Restangular) {
 
 	// retrieve language from backend - is set in ng-app HTML element
 	gettextCatalog.currentLanguage = $rootScope.lang;
@@ -140,6 +140,20 @@ angular.module('Music').controller('MainController',
 			}
 		});
 	};
+
+	// adjust controls bar width to not overlap with the scroll bar
+	function adjustControlsBarWidth() {
+		try {
+			var controlsWidth = $window.innerWidth - getScrollBarWidth();
+			$('#controls').css('width', controlsWidth);
+			$('#controls').css('min-width', controlsWidth);
+		}
+		catch (exception) {
+			console.log("No getScrollBarWidth() in core");
+		}
+	}
+	$($window).resize(adjustControlsBarWidth);
+	adjustControlsBarWidth();
 
 	// initial lookup if new files are available
 	$scope.processNextScanStep(1);


### PR DESCRIPTION
Fixed the scroll bar being hidden behind the controls bar. The implementation is based on the fix of similar problem in the Mail app: https://github.com/owncloud/mail/pull/874.