### PR TITLE
Fixed a layout bug in the positioning of the load indicator

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -23,7 +23,9 @@
 }
 
 #app-view {
+	position: absolute;
 	height: 100%;
+	width: 100%;
 	padding-right: 50px;
 }
 


### PR DESCRIPTION
Music app shows a spinning loading indicator while it is loading the albums. This indicator was not centered properly on the screen but was shown in the lowest third of the screen. Also, there was a scroll bar in the loading view although there was nothing to see below. The indicator did end up in the middle of the screen if the view was scrolled all the way down.

This happened because the app-view element was set to be as large as the window, but it was not positioned to the start of the window. It was relatively positioned below some invisible elements.