### PR TITLE
Fixed album deletion, Scrutinizer issues, and tests

### DIFF
--- a/db/albummapper.php
+++ b/db/albummapper.php
@@ -13,10 +13,9 @@
 namespace OCA\Music\Db;
 
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\Mapper;
 use OCP\IDb;
 
-class AlbumMapper extends Mapper {
+class AlbumMapper extends BaseMapper {
 
 	public function __construct(IDb $db){
 		parent::__construct($db, 'music_albums', '\OCA\Music\Db\Album');
@@ -190,22 +189,6 @@ class AlbumMapper extends Mapper {
 	}
 
 	/**
-	 * @param integer[] $albumIds
-	 */
-	public function deleteById($albumIds){
-		if(count($albumIds) === 0) {
-			return;
-		}
-
-		$questionMarks = array();
-		for($i = 0; $i < count($albumIds); $i++){
-			$questionMarks[] = '?';
-		}
-		$sql = 'DELETE FROM `*PREFIX*music_albums` WHERE `id` IN ('. implode(',', $questionMarks) . ')';
-		$this->execute($sql, $albumIds);
-	}
-
-	/**
 	 * @param integer $coverFileId
 	 * @param integer $parentFolderId
 	 */
@@ -289,19 +272,6 @@ class AlbumMapper extends Mapper {
 				SET `cover_file_id` = ? WHERE `id` = ?';
 		$params = array($imageId, $albumId);
 		$this->execute($sql, $params);
-	}
-
-	/**
-	 * @param string $userId
-	 * @return integer
-	 */
-	public function count($userId){
-		$sql = 'SELECT COUNT(*) AS count FROM `*PREFIX*music_albums` '.
-			'WHERE `user_id` = ?';
-		$params = array($userId);
-		$result = $this->execute($sql, $params);
-		$row = $result->fetch();
-		return $row['count'];
 	}
 
 	/**

--- a/db/albummapper.php
+++ b/db/albummapper.php
@@ -68,7 +68,7 @@ class AlbumMapper extends BaseMapper {
 	 */
 	public function getAlbumArtistsByAlbumId($albumIds){
 		$questionMarks = array();
-		for($i = 0; $i < count($albumIds); $i++){
+		for($i = 0, $count = count($albumIds); $i < $count; $i++){
 			$questionMarks[] = '?';
 		}
 		$sql = 'SELECT DISTINCT `track`.`artist_id`, `track`.`album_id` '.
@@ -140,7 +140,7 @@ class AlbumMapper extends BaseMapper {
 	 * @param string|null $albumName name of the album
 	 * @param string|integer|null $albumYear year of the album release
 	 * @param string|integer|null $discNumber disk number of this album's disk
-	 * @param integer|null $artistId ID of the album artist
+	 * @param integer|null $albumArtistId ID of the album artist
 	 * @param string $userId the user ID
 	 * @return Album[]
 	 */

--- a/db/albummapper.php
+++ b/db/albummapper.php
@@ -201,8 +201,6 @@ class AlbumMapper extends Mapper {
 		for($i = 0; $i < count($albumIds); $i++){
 			$questionMarks[] = '?';
 		}
-		$sql = 'DELETE FROM `*PREFIX*music_album_artists` WHERE `album_id` IN ('. implode(',', $questionMarks) . ')';
-		$this->execute($sql, $albumIds);
 		$sql = 'DELETE FROM `*PREFIX*music_albums` WHERE `id` IN ('. implode(',', $questionMarks) . ')';
 		$this->execute($sql, $albumIds);
 	}

--- a/db/artistmapper.php
+++ b/db/artistmapper.php
@@ -12,10 +12,9 @@
 
 namespace OCA\Music\Db;
 
-use OCP\AppFramework\Db\Mapper;
 use OCP\IDb;
 
-class ArtistMapper extends Mapper {
+class ArtistMapper extends BaseMapper {
 
 	public function __construct(IDb $db){
 		parent::__construct($db, 'music_artists', '\OCA\Music\Db\Artist');
@@ -112,32 +111,6 @@ class ArtistMapper extends Mapper {
 	public function findAllByName($artistName, $userId, $fuzzy = false){
 		$sqlAndParams = $this->makeFindByNameSqlAndParams($artistName, $userId, $fuzzy);
 		return $this->findEntities($sqlAndParams['sql'], $sqlAndParams['params']);
-	}
-
-	/**
-	 * @param integer[] $artistIds
-	 */
-	public function deleteById($artistIds){
-		if(count($artistIds) === 0)
-			return;
-		$questionMarks = array();
-		for($i = 0; $i < count($artistIds); $i++){
-			$questionMarks[] = '?';
-		}
-		$sql = 'DELETE FROM `*PREFIX*music_artists` WHERE `id` IN ('. implode(',', $questionMarks) . ')';
-		$this->execute($sql, $artistIds);
-	}
-
-	/**
-	 * @param string $userId
-	 */
-	public function count($userId){
-		$sql = 'SELECT COUNT(*) AS count FROM `*PREFIX*music_artists` '.
-			'WHERE `user_id` = ?';
-		$params = array($userId);
-		$result = $this->execute($sql, $params);
-		$row = $result->fetch();
-		return $row['count'];
 	}
 
 }

--- a/db/artistmapper.php
+++ b/db/artistmapper.php
@@ -46,7 +46,7 @@ class ArtistMapper extends BaseMapper {
 	 */
 	public function findMultipleById($artistIds, $userId){
 		$questionMarks = array();
-		for($i = 0; $i < count($artistIds); $i++){
+		for($i = 0, $count = count($artistIds); $i < $count; $i++){
 			$questionMarks[] = '?';
 		}
 		$sql = $this->makeSelectQuery('AND `artist`.`id` IN (' .

--- a/db/basemapper.php
+++ b/db/basemapper.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * ownCloud - Music app
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
+ * @copyright Pauli Järvinen 2016
+ */
+
+namespace OCA\Music\Db;
+
+use OCP\AppFramework\Db\Mapper;
+use OCP\IDb;
+
+/**
+ * Common base class for data access classes of the Music app
+ */
+class BaseMapper extends Mapper {
+
+	public function __construct(IDb $db, $tableName, $entityClass=null){
+		parent::__construct($db, $tableName, $entityClass);
+	}
+
+	/**
+	 * @param integer[] $ids  IDs of the entities to be deleted
+	 */
+	public function deleteById($ids){
+		if(count($ids) === 0) {
+			return;
+		}
+		$questionMarks = array();
+		for($i = 0; $i < count($ids); $i++){
+			$questionMarks[] = '?';
+		}
+		$sql = 'DELETE FROM `' . $this->getTableName() . '` WHERE `id` IN ('. implode(',', $questionMarks) . ')';
+		$this->execute($sql, $ids);
+	}
+
+	/**
+	 * @param string $userId
+	 */
+	public function count($userId){
+		$sql = 'SELECT COUNT(*) AS count FROM `' . $this->getTableName() . '` '.
+			'WHERE `user_id` = ?';
+		$params = array($userId);
+		$result = $this->execute($sql, $params);
+		$row = $result->fetch();
+		return $row['count'];
+	}
+
+}

--- a/db/basemapper.php
+++ b/db/basemapper.php
@@ -28,11 +28,12 @@ class BaseMapper extends Mapper {
 	 * @param integer[] $ids  IDs of the entities to be deleted
 	 */
 	public function deleteById($ids){
-		if(count($ids) === 0) {
+		$count = count($ids);
+		if($count === 0) {
 			return;
 		}
 		$questionMarks = array();
-		for($i = 0; $i < count($ids); $i++){
+		for($i = 0; $i < $count; $i++){
 			$questionMarks[] = '?';
 		}
 		$sql = 'DELETE FROM `' . $this->getTableName() . '` WHERE `id` IN ('. implode(',', $questionMarks) . ')';

--- a/db/trackmapper.php
+++ b/db/trackmapper.php
@@ -12,10 +12,9 @@
 
 namespace OCA\Music\Db;
 
-use OCP\AppFramework\Db\Mapper;
 use OCP\IDb;
 
-class TrackMapper extends Mapper {
+class TrackMapper extends BaseMapper {
 
 	public function __construct(IDb $db){
 		parent::__construct($db, 'music_tracks', '\OCA\Music\Db\Track');
@@ -136,19 +135,6 @@ class TrackMapper extends Mapper {
 		$sql = 'SELECT COUNT(*) AS count FROM `*PREFIX*music_tracks` `track` '.
 			'WHERE `track`.`user_id` = ? AND `track`.`album_id` = ?';
 		$params = array($userId, $albumId);
-		$result = $this->execute($sql, $params);
-		$row = $result->fetch();
-		return $row['count'];
-	}
-
-	/**
-	 * @param string $userId
-	 * @return integer
-	 */
-	public function count($userId){
-		$sql = 'SELECT COUNT(*) AS count FROM `*PREFIX*music_tracks` '.
-			'WHERE `user_id` = ?';
-		$params = array($userId);
 		$result = $this->execute($sql, $params);
 		$row = $result->fetch();
 		return $row['count'];

--- a/tests/features/AmpacheAPI.feature
+++ b/tests/features/AmpacheAPI.feature
@@ -9,7 +9,7 @@ Feature: Ampache API
     Then I should get:
       | name                     | albums | songs |
       | Diablo Swing Orchestra   | 1      | 5     |
-      | Pascalb / Pascal Boiseau | 1      | 3     |
+      | Pascal Boiseau - Pascalb | 1      | 3     |
       | SimonBowman              | 2      | 5     |
 
   Scenario: List filtered artists
@@ -34,7 +34,7 @@ Feature: Ampache API
     Then I should get:
       | name                                                | artist                   | tracks | year |
       | Instrumental Film Music Vol 1                       | SimonBowman              | 2      | 2013 |
-      | Nuance                                              | Pascalb / Pascal Boiseau | 3      | 2006 |
+      | Nuance                                              | Pascal Boiseau - Pascalb | 3      | 2006 |
       | Orchestral Film Music Vol 1                         | SimonBowman              | 3      | 2013 |
       | The Butcher s Ballroom                              | Diablo Swing Orchestra   | 5      | 2009 |
 
@@ -44,7 +44,7 @@ Feature: Ampache API
     And I request the "albums" resource
     Then I should get:
       | name                                                | artist                   | tracks | year |
-      | Nuance                                              | Pascalb / Pascal Boiseau | 3      | 2006 |
+      | Nuance                                              | Pascal Boiseau - Pascalb | 3      | 2006 |
 
   Scenario: List exact filtered albums
     Given I am logged in with an auth token
@@ -60,12 +60,12 @@ Feature: Ampache API
     And I request the "songs" resource
     Then I should get:
       | title                          | artist      | album                             | time | track |
-      | Aç                             | Pascalb / Pascal Boiseau | Nuance               | 187  | 7     |
+      | Aç                             | Pascal Boiseau - Pascalb | Nuance               | 187  | 7     |
       | Balrog Boogie                  | Diablo Swing Orchestra | The Butcher s Ballroom | 234  | 1     |
       | Forgotten Days                 | SimonBowman | Instrumental Film Music Vol 1     | 195  | 1     |
       | Gunpowder Chant                | Diablo Swing Orchestra | The Butcher s Ballroom | 111  | 7     |
       | Heroines                       | Diablo Swing Orchestra | The Butcher s Ballroom | 322  | 2     |
-      | Médiane                        | Pascalb / Pascal Boiseau | Nuance               | 203  | 1     |
+      | Médiane                        | Pascal Boiseau - Pascalb | Nuance               | 203  | 1     |
       | Nocturne                       | SimonBowman | Instrumental Film Music Vol 1     | 142  | 2     |
       | Poetic Pitbull Revolutions     | Diablo Swing Orchestra | The Butcher s Ballroom | 288  | 3     |
       | Rag Doll Physics               | Diablo Swing Orchestra | The Butcher s Ballroom | 233  | 4     |
@@ -78,7 +78,7 @@ Feature: Ampache API
     Then I should get:
       | title                            | artist                   | album                          | time | track |
       | Gunpowder Chant                  | Diablo Swing Orchestra   | The Butcher s Ballroom         | 111  | 7     |
-      | Médiane                          | Pascalb / Pascal Boiseau | Nuance                         | 203  | 1     |
+      | Médiane                          | Pascal Boiseau - Pascalb | Nuance                         | 203  | 1     |
 
   Scenario: List songs that contain "Mediane"
     Given I am logged in with an auth token
@@ -87,4 +87,4 @@ Feature: Ampache API
     And I request the "songs" resource
     Then I should get:
       | title                            | artist                   | album                          | time | track |
-      | Médiane                          | Pascalb / Pascal Boiseau | Nuance                         | 203  | 1     |
+      | Médiane                          | Pascal Boiseau - Pascalb | Nuance                         | 203  | 1     |

--- a/utility/scanner.php
+++ b/utility/scanner.php
@@ -414,8 +414,6 @@ class Scanner extends PublicEmitter {
 		foreach ($sqls as $sql) {
 			$this->db->executeUpdate($sql, array($userId));
 		}
-
-		$this->db->executeUpdate('DELETE FROM `*PREFIX*music_album_artists` WHERE `album_id` NOT IN (SELECT `id` FROM `*PREFIX*music_albums` GROUP BY `id`);');
 	}
 
 	private static function isNullOrEmpty($string) {


### PR DESCRIPTION
- When the last track of an album was removed, the album was supposed to be removed from the database. This didn't work because the function AlbumMapper.deleteById tried to modify also table *PREFIX*music_album_artists which no longer exists in the Music app. This caused an exception, error was logged, and the empty album was never removed from the database.
- Similar problem was present when the path to music library was changed from the user personal settings. Here it didn't cause any functional failure, but an error was logged.