### PR TITLE
Improved the layout of the "New music available" and "Scanning" boxes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -199,7 +199,20 @@
 	position: absolute;
 	top: 0;
 	background-color: #fff;
-	padding: 12px;
+	padding: 20px 50px;
+	z-index: 1;
+	width: auto;
+	margin-left: 50%;
+	transform: translateX(-50%);
+	-ms-transform: translateX(-50%);
+}
+
+#toScan:hover * {
+	color: #000;
+	/* opacity */
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
+	filter: alpha(opacity = 100);
+	opacity: 1;
 }
 
 #updateData {
@@ -220,7 +233,7 @@
 
 #updateData:hover, #updateData:focus {
 	/* opacity */
-	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=40)";
+	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)";
 	filter: alpha(opacity = 100);
 	opacity: 1;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -198,7 +198,7 @@
 #scanning, #toScan {
 	position: absolute;
 	top: 0;
-	background-color: #fff;
+	background-color: rgba(255,255,255,0.95);
 	padding: 20px 50px;
 	z-index: 1;
 	width: auto;


### PR DESCRIPTION
When there are already some albums in the library, and new music files become available, the "New music available" box is overlayed on top of the album view. This box used to have quite odd layout as it spanned the whole screen width while its content could fit much smaller box. Also, it overlayed the album art and the track names but not anything written in dimmed font (track numbers, album years, "show all X songs"). 

After this PR, the box width is only the content width plus some padding and it overlays also the dimmed texts. Also, the contents of the "New music available" box are now highlighted on hover.

Before:
![before](https://cloud.githubusercontent.com/assets/8565946/19362857/e4f5523c-9190-11e6-85ef-54e6a3e16eb2.png)

After:
![after](https://cloud.githubusercontent.com/assets/8565946/19362866/ee5bfc7c-9190-11e6-9d6a-0ff72e69fe01.png)
