### PR TITLE
Improved the layout of the "New music available" and "Scanning" boxes, part 2

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -198,7 +198,7 @@
 }
 
 #scanning, #toScan {
-	position: absolute;
+	position: fixed;
 	top: 0;
 	background-color: rgba(255,255,255,0.95);
 	padding: 20px 50px;

--- a/templates/partials/overview.php
+++ b/templates/partials/overview.php
@@ -1,7 +1,7 @@
-<div ng-hide="artists" id="emptycontent">
-	<div class="icon-audio svg" ng-hide="loading"></div>
-	<h2 ng-hide="loading" translate>No music found</h2>
-	<p ng-hide="loading" translate>Upload music in the files app to listen to it here</p>
+<div id="emptycontent" ng-hide="toScan || scanning || loading || artists">
+	<div class="icon-audio svg"></div>
+	<h2 translate>No music found</h2>
+	<p translate>Upload music in the files app to listen to it here</p>
 </div>
 
 <img id="updateData" ng-show="updateAvailable"


### PR DESCRIPTION
The PR #544 caused unexpected issue on empty library, as the "No music found" label became partially visible on the background of the "New music available" label (see the picture). Now the former is properly hidden when it is not applicable.
![emptycontent_overlap](https://cloud.githubusercontent.com/assets/8565946/19821923/8f41be68-9d69-11e6-9e8b-e708ca89145d.png)

Also, the "New music available" label now stays in a fixed position when the album view is scrolled. See the commit message for rationale. 
