### PR TITLE
Update getid3 library to a patched version

### DIFF
--- a/3rdparty/getID3/README.md
+++ b/3rdparty/getID3/README.md
@@ -77,7 +77,7 @@ Reads & parses (to varying degrees):
 + audio-lossy:
   * MP3/MP2/MP1
   * MPC / Musepack
-  * Ogg (Vorbis, OggFLAC, Speex)
+  * Ogg (Vorbis, OggFLAC, Speex, Opus)
   * AAC / MP4
   * AC3
   * DTS
@@ -186,7 +186,7 @@ if ($fp_remote = fopen($remotefilename, 'rb')) {
         fclose($fp_local);
         // Initialize getID3 engine
         $getID3 = new getID3;
-        $ThisFileInfo = $getID3->analyze($filename);
+        $ThisFileInfo = $getID3->analyze($localtempfilename);
         // Delete temporary file
         unlink($localtempfilename);
     }

--- a/3rdparty/getID3/changelog.txt
+++ b/3rdparty/getID3/changelog.txt
@@ -18,6 +18,10 @@
 Version History
 ===============
 
+1.9.12-oc_music_app: [2016-10-30] Pauli Järvinen
+    A patched version for the ownCloud Music app. Consists of 1.9.12 + commit 0e6c1a3bcef
+    which fixes parsing of non-regular files (like the "oc://" paths used in ownCloud).
+
 1.9.12: [2016-03-02] James Heinrich
     Â» Add support for Direct Stream Digital (DSD) /
       DSD Storage Facility (DSF) file format

--- a/3rdparty/getID3/changelog.txt
+++ b/3rdparty/getID3/changelog.txt
@@ -10,18 +10,69 @@
 //                                                            ///
 /////////////////////////////////////////////////////////////////
 
-        » denotes a major feature addition/change
-        ¤  denotes a change in the returned structure
+        Â» denotes a major feature addition/change
+        Â¤  denotes a change in the returned structure
         !  denotes a cry for help from developers
 * Bugfix:  denotes a fixed bug
 
 Version History
 ===============
 
+1.9.12: [2016-03-02] James Heinrich
+    Â» Add support for Direct Stream Digital (DSD) /
+      DSD Storage Facility (DSF) file format
+    Â» Add detection (not parsing) of WebP image format
+    * bugfix (#1910): Quicktime embedded images
+
+1.9.11: [2015-12-24] James Heinrich
+    * bugfix (G:64): update constructor syntax for PHP 7
+    * bugfix (G:62): infinite loop in large PNG files
+    * bugfix (G:61): ID3v2 remove BOM from frame descriptions
+    * bugfix (G:60): missing "break" in module.audio-video.quicktime.php
+    * bugfix (G:59): .gitignore comments
+    * bugfix (G:58): inconsistency in relation to module.tag.id3v2.php
+    * bugfix (G:57): comparing instead of assign
+    * bugfix (G:56): unsupported MIME type "audio/x-wave"
+    * bugfix (G:55): readme.md variable reference
+    * bugfix (G:54): QuickTime false 1000fps
+    * bugfix (G:53): Quicktime / ID3v2 multiple genres
+    * bugfix (G:52): sys_get_temp_dir in GetDataImageSize
+    * bugfix (#1903): Quicktime meta atom not parsed
+    * demo.joinmp3.php enhancements
+    * m4b (audiobook) chapters not parsed correctly
+    * sqlite3 caching not working
+
+1.9.10: [2015-09-14] James Heinrich
+    * bugfix (G:49): Declaration of getID3_cached_sqlite3
+    * bugfix (#1892): extension.cache.mysql
+    * bugfix (#1891): duplicate default clause [Quicktime]
+    * bugfix (G:41): incorrect MP3 playtime
+    * bugfix: iconv problems on musl with //TRANSLIT
+    * Add arguments to analyze() for original filesize (and filename)
+    * ID3v2 simplify handling of multiple genres
+    * Corrected merging of multiple genres for ID3v2
+    * getid3_lib::GetDataImageSize return false on error
+
+1.9.9: [2014-12-18] James Heinrich
+    Â» Added basic support for OggOpus
+    Â» Add ID3v2 CHAP + CTOC support
+    * Add composer autoloader
+    * bugfix: removed non-printable ASCII in comment
+    * bugfix: possible memory leak in OggFLAC
+    * bugfix: sys_get_temp_dir undefined before PHP 5.2.1
+    * bugfix: improved fix for XXE security issue (CVE-2014-2053)
+      (thanks nacinØwordpress*org)
+    * bugfix: G:25 ID3v2 LINK utf8_encode not defined
+    * bugfix: G:22 ID3v2 TXXX description encoding
+    * bugfix: #1855 - copy image height/width/etc to comments
+    * bugfix: #1855 - PHP errors in badly written APE/ID3v2 tags
+    * bugfix: #1845 - Quicktime parsing with no PHP memory_limit
+    * bugfix: #1828 - ID3v2 writing unknown frame names
+
 1.9.8: [2014-05-11] James Heinrich
-    » Add support for AMR (Adaptive Multi-Rate audio codec)
+    Â» Add support for AMR (Adaptive Multi-Rate audio codec)
       new file: module.audio.amr.php
-    » Added composer.json, registered on packagist.org
+    Â» Added composer.json, registered on packagist.org
     * Added workaround for PHP Bug #39923 (undefined constant IMG_JPG)
     * Bugfix: (#1813) avoid running out of memory when parsing large
       Quicktime files
@@ -44,7 +95,7 @@ Version History
     * Bugfix: all source files converted to UTF-8
 
 1.9.6: [2013-06-03] James Heinrich
-    » getID3() is now licensed under GPL / LGPL / MozillaPL / gCL
+    Â» getID3() is now licensed under GPL / LGPL / MozillaPL / gCL
       See license.txt for more details.
     * Bugfix: (#1550) Quicktime video track sample description parsed
       incorrectly
@@ -53,11 +104,11 @@ Version History
     * Bugfix: option_max_2gb_check should issue warning not error on >2GB
 
 1.9.5: [2013-02-20] James Heinrich, Dmitry Arkhipov
-    » DTS-in-WAV now properly supported
-    ¤ DSS files return additional data in new keys, and some existing
+    Â» DTS-in-WAV now properly supported
+    Â¤ DSS files return additional data in new keys, and some existing
       keys have been renamed
     * Bugfix: open_basedir not parsed correctly under Windows
-      (thanks yannick*jamontØgmail*com)
+      (thanks yannick*jamontÃ˜gmail*com)
     * Bugfix: [demo/demo.browse] might not display file or directory name
       on PHP >=5.4.0 if filename not UTF-8 friendly
     * Bugfix: [demo/demo.zip] could read more uncompressed data than
@@ -76,24 +127,24 @@ Version History
     * Bugfix: (#1474) unneccesary call to GetDataImageSize in JPEG module
     * Bugfix: (#1470) GIF files falsely detected as TS format
     * Bugfix: (#1431) Matroska did not parse PixelCrop* / DisplayUnit
-      (thanks jgerberØwikimedia*org)
+      (thanks jgerberÃ˜wikimedia*org)
     * Bugfix: (#1430) split ID3v2 text values on null separator
     * Bugfix: (#1426) MS Office 2007 file format now recognized as zip.msoffice
     * Bugfix: (#1423) optimized CreateDeepArray function
     * Bugfix: (#1415) add support for DS2 variant of DSS
 
 1.9.4b1: [2012-10-05] James Heinrich, Dmitry Arkhipov, Karl G. Holz
-    » New module: extension.cache.sqlite3.php (by Karl G. Holz)
-    » New demo: demos/getid3.demo.dirscan.php (by Karl G. Holz)
-    » PHP5 standards improvements (thanks phansysØgmail*com)
-    » more reliable >4GB file size parsing using COM (if available)
+    Â» New module: extension.cache.sqlite3.php (by Karl G. Holz)
+    Â» New demo: demos/getid3.demo.dirscan.php (by Karl G. Holz)
+    Â» PHP5 standards improvements (thanks phansysÃ˜gmail*com)
+    Â» more reliable >4GB file size parsing using COM (if available)
       Scripting.FileSystemObject rather than parsing `dir` output
     * added support for FLAC inside Matroska (audio bitrate cannot
         be determined in this case)
     * XMP module now returns all tags, not just whitelisted ones
     * (#1297) Added detection of MPEG Transport Stream files.
       Stub module.audio-video.ts.php incomplete
-    * (#1383) removed unneeded ?> tags (thanks daveØholyfield*info)
+    * (#1383) removed unneeded ?> tags (thanks daveÃ˜holyfield*info)
     * Bugfix: XMP returns attributes array not just value strings
     * Bugfix: (#1369) ID3v2 IPLS contents not parsed
     * Bugfix: (#1357) demo.mysql.php mysql_table_exists() failed
@@ -130,11 +181,11 @@ Version History
 
 
 1.9.2: [2011-12-08] James Heinrich, Dmitry Arkhipov
-	» significant rewrite to module.audio-video.matroska.php
-    ¤ (#1256) ID3 tags in AIFF 'ID3 ' chunks now parsed
-    ¤ (#1039) iXML data in WAV files now returned and parsed into
+	Â» significant rewrite to module.audio-video.matroska.php
+    Â¤ (#1256) ID3 tags in AIFF 'ID3 ' chunks now parsed
+    Â¤ (#1039) iXML data in WAV files now returned and parsed into
         [riff][WAVE][iXML][0][data] and [riff][WAVE][iXML][0][parsed]
-    ¤ [playtime_string] now returns M:SS if less than 1 hour, and
+    Â¤ [playtime_string] now returns M:SS if less than 1 hour, and
         H:MM:SS if 1 hour or longer
     * Bugfix: (#1266) variable tablename: extension.cache.mysql.php
     * Bugfix: (#1265) unescaped # in regex in write.id3v2.php
@@ -151,7 +202,7 @@ Version History
 
 
 1.9.1: [2011-08-10] James Heinrich
-    ¤ ASF Extended Header Object data now (partially) parsed
+    Â¤ ASF Extended Header Object data now (partially) parsed
     * Default getID3 encoding now set to UTF-8 not ISO-8859-1
     * Bugfix: (#1212) truncated Matroska files may result in
         infinite loop and memory exhaustion
@@ -172,21 +223,21 @@ Version History
 
 
 1.9.0: [2011-06-20] James Heinrich
-    » changed all module classes to have proper constructors
+    Â» changed all module classes to have proper constructors
       with the actual analysis code moved to function Analyze()
     * removed unnecessary ob_* calls, replaced with appropriate
       checks and judicious use of @ error suppression
-    ¤ GETID3_VERSION constant replaced with $getID3->version()
-    ¤ picture data is now returned only in the original source
+    Â¤ GETID3_VERSION constant replaced with $getID3->version()
+    Â¤ picture data is now returned only in the original source
       location and [comments][picture], it is no longer replicated
       in [comments_html], [tags] or [tags_html]
-    ¤ Matroska tags are now returned in [comments] as per normal
-    ¤ Matroska tags are better supported, including pictures
-    ¤ GPS data in MP4 files (e.g. iPhone) is now parsed (#1157)
-    ¤ Matroska audio/video tracks with a default flag, the default
+    Â¤ Matroska tags are now returned in [comments] as per normal
+    Â¤ Matroska tags are better supported, including pictures
+    Â¤ GPS data in MP4 files (e.g. iPhone) is now parsed (#1157)
+    Â¤ Matroska audio/video tracks with a default flag, the default
       stream flag is now copied to [audio|video][streams] (#1147)
-    ¤ Nikon-specific data (NCDT atom) in Quicktime videos now parsed
-    ¤ QuickTime atoms 'meta' and 'data' now (mostly) parsed
+    Â¤ Nikon-specific data (NCDT atom) in Quicktime videos now parsed
+    Â¤ QuickTime atoms 'meta' and 'data' now (mostly) parsed
     * Bugfix: remove false warning of junk data on WAV+ID3v1
     * Bugfix: DolbyDigitalWAV files returned wrong audio bitrate
     * Bugfix: large attachment data in Matroska tags were not
@@ -220,15 +271,15 @@ Version History
 
 
 1.8.5: [2011-02-18] James Heinrich
-    » support >2GB files on 64-bit PHP
+    Â» support >2GB files on 64-bit PHP
       - note current unofficial 64-bit PHP builds for Windows
         do not actually support 64-bit integers so are still
         subject to normal 32-bit limits (2GB) for file functions
-    » PHP v5.0.5 now minimum required version.
+    Â» PHP v5.0.5 now minimum required version.
       Removed obsolte functions from getid3.lib.php:
         md5_file, sha1_file, image_type_to_mime_type
-    » IDivX tags now parsed on AVI files
-    ¤ embedded image data is returned inside [comments][picture]
+    Â» IDivX tags now parsed on AVI files
+    Â¤ embedded image data is returned inside [comments][picture]
       in a 2-element array (data, image_mime) for all formats
     * $this->overwrite_tags=false is now known to be buggy and
       has been disabled for this version until a full review
@@ -266,8 +317,8 @@ Version History
 
 
 1.8.3: [2011-01-18] James Heinrich
-    » magic_quotes_gpc must now be disabled to use getID3
-    » replace all error-suppressing @$variable calls with
+    Â» magic_quotes_gpc must now be disabled to use getID3
+    Â» replace all error-suppressing @$variable calls with
       isset() or empty() as appropriate for some configurations
       where @ does not act to suppress warnings of undefined
       variables (e.g. support forum thread #798)
@@ -280,16 +331,16 @@ Version History
       prevent "Undefined index: track_data_offsets" errors
       in Matroska files
     * Bugfix: [riff] prevent errors when RIFF.WAVE.BEXT chunk
-      contains null date/time  (thanks moysevichØgmail*com)
+      contains null date/time  (thanks moysevichÃ˜gmail*com)
     * Bugfix: [quicktime] prevent divide-by-zero errors if
       time_to_sample_table has zero-sample entry
-      (thanks moysevichØgmail*com)
+      (thanks moysevichÃ˜gmail*com)
 
 
 1.8.2: [2010-12-06] James Heinrich
     * include startup warning for PHP < v5
     * magic_quotes_runtime must now be disabled to use getID3
-    ¤ MusicBrainz / AmpliFIND data more accessible in returned data
+    Â¤ MusicBrainz / AmpliFIND data more accessible in returned data
       from Quicktime-style files (e.g. MP4/AAC)
     * Bugfix: (#1079) wrong encoding might be used for ID3v2
         text data, and/or garbage data prepended before text
@@ -330,79 +381,79 @@ Version History
 
 
 1.8.0: [2010-11-23] James Heinrich
-    » Changes required for PHP v5.3+ compatability, including:
+    Â» Changes required for PHP v5.3+ compatability, including:
       - change ereg* functions to preg_* equivalents
       - declare functions static as needed
       note: users of PHP v4.x may need to stay with getID3 v1.7.x
-    » Added CUE (cuesheet) support
+    Â» Added CUE (cuesheet) support
       new file: module.misc.cue.php
-      (thanks Nigel Barnes ngbarnesØhotmail*com)
-    » Added XMP (Adobe Extensible Metadata Platform) support
+      (thanks Nigel Barnes ngbarnesÃ˜hotmail*com)
+    Â» Added XMP (Adobe Extensible Metadata Platform) support
       currently used with module.graphic.jpg.php
       new file: module.tag.xmp.php
-      (thanks Nigel Barnes ngbarnesØhotmail*com)
-    ¤ [jpg][exif][GPS][computed] now exists when possible with
+      (thanks Nigel Barnes ngbarnesÃ˜hotmail*com)
+    Â¤ [jpg][exif][GPS][computed] now exists when possible with
       calculated values (decimal latitude, longitude, altitude, time)
-    ¤ Prevent clobbering WMA artist with albumartist value; added WMA
+    Â¤ Prevent clobbering WMA artist with albumartist value; added WMA
       partofset tag; added WMA tag picture data to WMA comments
-      (thanks ngbarnesØhotmail*com)
-    ¤ RIFF.WAVE.SNDM (SoundMiner) metadata now parsed
-      (thanks emerrittØwbgu*bgsu*edu)
-    ¤ FLAC embedded pictures now return [data_length] key
-      (thanks darrenburnhillØhotmail*com)
+      (thanks ngbarnesÃ˜hotmail*com)
+    Â¤ RIFF.WAVE.SNDM (SoundMiner) metadata now parsed
+      (thanks emerrittÃ˜wbgu*bgsu*edu)
+    Â¤ FLAC embedded pictures now return [data_length] key
+      (thanks darrenburnhillÃ˜hotmail*com)
     * added support for a number of new comment atom types added in
-      iTunes v4.0-v7.0  (thanks ngbarnesØhotmail*com)
+      iTunes v4.0-v7.0  (thanks ngbarnesÃ˜hotmail*com)
     * demo.browse.php now shows video resolution and framerate (if no
       artist or title info present)
     * additional FLV details parsed, may be faster as well
-      (thanks ngbarnesØhotmail*com)
+      (thanks ngbarnesÃ˜hotmail*com)
     * Bugfix: DSS files longer than 60 seconds had wrong playtime
     * Bugfix: possible empty array encountered in APE tags
-      (thanks csnaitsirchØweb*de)
+      (thanks csnaitsirchÃ˜web*de)
     * Bugfix: prevent fatal error when calling BigEndian2Int() on
-      zero-length string  (thanks taylor*fausakØgmail*com)
+      zero-length string  (thanks taylor*fausakÃ˜gmail*com)
     * Bugfix: prevent errors when parsing invalid Vorbis comments
-      (thanks dr*dieselØgmail*com)
+      (thanks dr*dieselÃ˜gmail*com)
     * Bugfix: files could not be analyzed from Windows shares
       (e.g. \\SERVER\Directory\Filename.mp3)
     * Bugfix: RAR file opening should use 'filenamepath'
-      (thanks adrien*gibratØgmail*com)
+      (thanks adrien*gibratÃ˜gmail*com)
     * Bugfix: [asf][codec_list_object][codec_entries][x][description]
       not containing expected comma-seperated values no longer aborts
-      (thanks larry_globusØyahoo*com)
+      (thanks larry_globusÃ˜yahoo*com)
     * Bugfix: [id3v2] UFID was not returning data
-      (thanks joostØdecock*org)
+      (thanks joostÃ˜decock*org)
 
 1.7.9: [2009-03-08] James Heinrich
-    » Added DSS (Digital Speech Standard) support
+    Â» Added DSS (Digital Speech Standard) support
       new file: module.audio.dss.php
-      (thanks luke*wilkinsØdtsam*com)
-    » Added MPC (Musepack) SV8 support
+      (thanks luke*wilkinsÃ˜dtsam*com)
+    Â» Added MPC (Musepack) SV8 support
       (thanks WaldoMonster)
-    ¤ some MPC [header] keys renamed to be the same between SV7/SV8
-    ¤ start aligning demos CSS styling with v2.x styles
+    Â¤ some MPC [header] keys renamed to be the same between SV7/SV8
+    Â¤ start aligning demos CSS styling with v2.x styles
       new file: demos/getid3.css
-    ¤ JPEG now returns parsed IPTC tags in [iptc]
-    ¤ getid3_lib::GetDataImageSize now requires $imageinfo parameter
-    ¤ better support for Matroska files with AC3/DTS/MP3/OGG audio
+    Â¤ JPEG now returns parsed IPTC tags in [iptc]
+    Â¤ getid3_lib::GetDataImageSize now requires $imageinfo parameter
+    Â¤ better support for Matroska files with AC3/DTS/MP3/OGG audio
       (support still lacking for AAC)
-    ¤ standardize ID3v2 TCMP key to 'part_of_a_set' between reading
-      and writing  (thanks aaron_stormØyahoo*com)
-    ¤ added ID3v2 keys 'TCMP','TCP' to for writing iTunes-style tags
-      (thanks aaron_stormØyahoo*com)
-    ¤ back-ported PICTURE tag handling in FLAC tags
+    Â¤ standardize ID3v2 TCMP key to 'part_of_a_set' between reading
+      and writing  (thanks aaron_stormÃ˜yahoo*com)
+    Â¤ added ID3v2 keys 'TCMP','TCP' to for writing iTunes-style tags
+      (thanks aaron_stormÃ˜yahoo*com)
+    Â¤ back-ported PICTURE tag handling in FLAC tags
       (thanks WaldoMonster)
-    ¤ added alternate method to get [video][frame_rate] from QuickTime
+    Â¤ added alternate method to get [video][frame_rate] from QuickTime
     * added partial support for "TCMP"/"TCP" ID3v2 frames (iTunes
       non-standard part-of-a-compilation tag)
-      (thanks aaron_stormØyahoo*com)
+      (thanks aaron_stormÃ˜yahoo*com)
     * slightly improved scanning through FLV files speed
       (thanks franki)
     * faster Matroska scanning by stopping at cluster chunks once
       needed header chunks are found (much faster for large files)
     * added workaround for broken tagging programs that miss terminating
       null byte for numeric ID3v2.4 genres
-      (thanks yam655Øgmail*com)
+      (thanks yam655Ã˜gmail*com)
     * Bugfix: MultiByteCharString2HTML() did not escape common HTML
       special characters like & and ?
     * Bugfix: cleaned up some malformed HTML errors in demo.browse.php
@@ -415,29 +466,29 @@ Version History
 
 
 1.7.8b3: [2008-07-13] James Heinrich
-    » Experimental partial support for files > 2GB (gets filesize
+    Â» Experimental partial support for files > 2GB (gets filesize
       from shell call to "dir" or "ls", parse files with PHP only
       up to 2GB limit). See readme.txt for details on what formats
       work properly and other limitations
-    » Initial support for Matroska. Has only been tested with a
+    Â» Initial support for Matroska. Has only been tested with a
       limited number of sample files, please report any bugs
-    » Experimental support for PHP-RAR reading. Known buggy, disabled
+    Â» Experimental support for PHP-RAR reading. Known buggy, disabled
       by default, enable with care
-    ¤ getid3_lib::CastAsInt() now returns ints up to 2^31 (not 2^30)
-    ¤ Quicktime: [video] now returns [frame_rate] and [fourcc] for MP4
+    Â¤ getid3_lib::CastAsInt() now returns ints up to 2^31 (not 2^30)
+    Â¤ Quicktime: [video] now returns [frame_rate] and [fourcc] for MP4
       video files
     * MP3: headerless VBR files now only have up to 10 blocks of 5000
       frames each scanned by default and bitrate extrapolated from that
-      distribution for speed  (thanks glau*stuffØridiculousprods*com)
+      distribution for speed  (thanks glau*stuffÃ˜ridiculousprods*com)
     * Quicktime: support "co64" atom
     * SWF: lower memory use when compressed SWF files processed
-      (thanks doughammondØblueyonder*co*uk)
+      (thanks doughammondÃ˜blueyonder*co*uk)
     * Bugfix: FLV height and width was calculated incorrectly
-      (thanks moysevichØgmail*com)
+      (thanks moysevichÃ˜gmail*com)
     * Bugfix: FLV GETID3_FLV_TAG_META parsed incorrectly
-      (thanks moysevichØgmail*com)
+      (thanks moysevichÃ˜gmail*com)
     * Bugfix: Quicktime: 'tkhd' matrix_v and matrix_d were switched
-      (thanks rjjmoroØhotmail*com)
+      (thanks rjjmoroÃ˜hotmail*com)
     * Bugfix: Quicktime: frame_rate was often incorrect for MP4 video
     * Bugfix: getid3_lib::CastAsInt returned -2147483648 when passed
       2147483648 (0x80000000)
@@ -466,29 +517,29 @@ Version History
       least shown correctly, if they happen due to other bugs)
     * Bugfix: Several ASF header values are invalid if the broadcast
       flag is set, getID3() now calculates these values in other
-      ways if the broadcast flag is set  (thanks fletchØpobox*com)
+      ways if the broadcast flag is set  (thanks fletchÃ˜pobox*com)
     * Bugfix: lyrics3-flags-lyrics field was always false, and there
       never was a lyrics3-flags-timestamp field present even though
       the lyrics3-raw-IND field consisted of "10" (lyrics present,
-      timestamp not present).  (thanks i*f*schulzØweb*de)
+      timestamp not present).  (thanks i*f*schulzÃ˜web*de)
     * Bugfix: TAR.GZ files produce PHP errors when
       option_gzip_parse_contents == true in module.archive.gzip.php
-      (thanks alan*harderØsun*com)
+      (thanks alan*harderÃ˜sun*com)
 
 
 1.7.8b1: [2007-01-08] Allan Hansen
-    » Major update to readme.txt
-    » PHP 4.2.0 required
-    » Tagwriter requires metaflac 1.1.1+ in order to write FLAC tags.
-    » Removed broken and non-fixable tagwriting module for real format.
+    Â» Major update to readme.txt
+    Â» PHP 4.2.0 required
+    Â» Tagwriter requires metaflac 1.1.1+ in order to write FLAC tags.
+    Â» Removed broken and non-fixable tagwriting module for real format.
     ! Developers please help fix the above module:
       http://www.getid3.org/phpBB3/viewtopic.php?t=677
-    » Avoided security issues with demo.browse.php, demo.write.php and
+    Â» Avoided security issues with demo.browse.php, demo.write.php and
       demo.mysql.php. These demos are now disabled by default and has
       to be enabled in the source.
     * Bugfix: id3v2 genre broken since 1.7.7.
-    » Added DTS module (module.audio.dts.php)
-    ¤ ASF/WMV files now return largest video stream dimensions in
+    Â» Added DTS module (module.audio.dts.php)
+    Â¤ ASF/WMV files now return largest video stream dimensions in
       [video][resolution_x] and [video][resolution_y]
     * Bugfix: Minor issues with midi module (avoid PHP_NOTICE).
     * Bugfix: Minor issues with lyrics3 (avoid PHP_NOTICE).
@@ -499,7 +550,7 @@ Version History
       video/x-ms-wmv for certain FourCCs.
     * Bugfix: PHP_NOTICE issues with broken ID3v2 tag/garbage.
     * Bugfix: PNG module broken in regards to gIFg and gIFx chunks.
-    » Removed detection of short filenames 8dot3 under windows, as
+    Â» Removed detection of short filenames 8dot3 under windows, as
       it only worked for English versions of windows and has other
       problems.
     * Bugfix: Some CBR MP3 files detected as VBR with plenty of warnings.
@@ -511,17 +562,17 @@ Version History
     * Bugfix: ID3v2 LINK frames iconv error.
     * Bugfix: ID3v2 padding length calculated incorrectly.
     * Bugfix: ID3v2.3 extended headers non-conformance
-    » SVG file detection.
-    » Added SVG user module (user_modules/module.graphic.svg.php).
+    Â» SVG file detection.
+    Â» Added SVG user module (user_modules/module.graphic.svg.php).
       Thanks to Roan Horning.
-    » PAR2 file detection (no parsing)
+    Â» PAR2 file detection (no parsing)
     * Bugfix: Wave files being detected as MP3.
     * Bugfix: ASF padding offset bug.
     * Bugfix: Shorten module not working for wav files with fmt
       chunks <> 16 bytes.
-    ¤ RIFF: Zero sized chunk invokes warning instead of error.
-    ¤ FLAC: Removed some ['raw'] keys.
-    ¤ MPC: Mime type returned: audio/x-musepack
+    Â¤ RIFF: Zero sized chunk invokes warning instead of error.
+    Â¤ FLAC: Removed some ['raw'] keys.
+    Â¤ MPC: Mime type returned: audio/x-musepack
 
 1.7.7: [2006-06-25] Allan Hansen
     * Bugfix: AAC static bitrate cache wrong result when parsing
@@ -534,26 +585,26 @@ Version History
     * Bugfix: Filenames not escapeshellarg() for md5_data and
       sha1_data (UNIX only).
     * Bugfix: UNIX: head and tail called with -cNNN instead of "-c NNN".
-    » Added detection support for PDF and MS Office documents
-      (*.doc, *.xls, *.pps, etc)  (thanks zeromassmediaØgmail*com)
-    ¤ Bugfix: ID3v2 "TDRC" frame now used as "year" in comments if TYER
+    Â» Added detection support for PDF and MS Office documents
+      (*.doc, *.xls, *.pps, etc)  (thanks zeromassmediaÃ˜gmail*com)
+    Â¤ Bugfix: ID3v2 "TDRC" frame now used as "year" in comments if TYER
       unavailable (TYER is deprecated in ID3v2.4)
-      (thanks matthiasØpanczyk*org)
-    ¤ Removed GETID3_OS_DIRSLASH, replaced with DIRECTORY_SEPARATOR
+      (thanks matthiasÃ˜panczyk*org)
+    Â¤ Removed GETID3_OS_DIRSLASH, replaced with DIRECTORY_SEPARATOR
     * Bugfix: added LAME preset guessing for presets 410,420,440,490
-      (thanks adminØlogbud*com)
+      (thanks adminÃ˜logbud*com)
     * Bugfix: Added escapeshellarg() call in getid3_lib::hash_data
-      (thanks towbØgmx*net)
-    » TAR module no longer reads entire file into memory
-    » FLV module no longer reads entire file into memory
+      (thanks towbÃ˜gmx*net)
+    Â» TAR module no longer reads entire file into memory
+    Â» FLV module no longer reads entire file into memory
     * Bugfix: added LAME preset guessing for presets 410,420,440,490
-      (thanks adminØlogbud*com)
+      (thanks adminÃ˜logbud*com)
     * Bugfix: Added escapeshellarg() call in getid3_lib::hash_data
-      (thanks towbØgmx*net)
+      (thanks towbÃ˜gmx*net)
     * Bugfix: Error message when padding in FLAC files were used up.
     * Bugfix: Shorten module not working under windows.
-    ¤ Bugfix: gmmktime() instead of mktime().
-    ¤ Using gmmktime() instead of mktime() in ISO, ZIP, PNG and RIFF
+    Â¤ Bugfix: gmmktime() instead of mktime().
+    Â¤ Using gmmktime() instead of mktime() in ISO, ZIP, PNG and RIFF
       modules to avoid E_STRICT notices with PHP5.1+.
     * Bugfix: ['comments_html'] and ['comments'] contains different
       value when having multiple tags (one of them ID3v1) and the
@@ -561,67 +612,67 @@ Version History
 
 1.7.6: [2006-03-12] James Heinrich
     * Rewrote getid3_lib::GetDataImageSize() to use GetImageSize()
-      instead of using code by filØrezox*com
+      instead of using code by filÃ˜rezox*com
     * Bugfix: incorrect dimensions from disabled Quicktime tracks
-      (thanks m-1Øgmx*net)
+      (thanks m-1Ã˜gmx*net)
     * Bugfix: ['codec'] key warning in module.audio-video.asf.php
-      (thanks niel*archerØblueyonder*co*uk)
+      (thanks niel*archerÃ˜blueyonder*co*uk)
     * Bugfix: undefined array in write.php
-      (thanks drewishØkatherinehouse*com)
+      (thanks drewishÃ˜katherinehouse*com)
     * Bugfix: DeleteAPEtag() incorrectly failing when no tag present
-      (thanks drewishØkatherinehouse*com)
+      (thanks drewishÃ˜katherinehouse*com)
     * Bugfix: ID3v2 writing frames with URL fields failing when URL
-      is not in ISO-8859-1  (thanks drewishØkatherinehouse*com)
+      is not in ISO-8859-1  (thanks drewishÃ˜katherinehouse*com)
     * Bugfix: PHP notices on bad ID3v2 frames
-      (thanks cw264701Øohiou*edu)
+      (thanks cw264701Ã˜ohiou*edu)
     * Bugfix: audio & video bitrates sometimes wrong in ASF files
-      (thanks kris_kauperØexcite*com)
+      (thanks kris_kauperÃ˜excite*com)
 
 1.7.5: [2005-12-29] James Heinrich
-    » Added FLV (FLash Video) support -- new file:
+    Â» Added FLV (FLash Video) support -- new file:
       module.audio-video.flv.php
       (thanks Seth Kaufman <seth@whirl-i-gig.com> for code)
-    » Real tags can now be written (previous Real tag writing
+    Â» Real tags can now be written (previous Real tag writing
       code was not supposed to be in public releases, as it
       was not complete)
-    » GETID3_HELPERAPPSDIR now autodetected under Windows
-    ¤ ASF lyrics now returned under [comments][lyrics]
+    Â» GETID3_HELPERAPPSDIR now autodetected under Windows
+    Â¤ ASF lyrics now returned under [comments][lyrics]
     * Bugfix: removed "--lowpass xxxxx" info from guessed
       LAME presets when source frequency <= 32kHz
     * Bugfix: ID3v2 extended header errors
     * Bugfix: missing ob_end_clean() in write.id3v2.php
-      (thanks rasherØgmail*com)
+      (thanks rasherÃ˜gmail*com)
 
 1.7.4: [2005-05-04] James Heinrich
-    ¤ Added ['quicktime']['hinting'] key (boolean)
-      (thanks jonØwebignition*net)
+    Â¤ Added ['quicktime']['hinting'] key (boolean)
+      (thanks jonÃ˜webignition*net)
     * Bugfix: major UTF-8 to UTF-16/ISO-8859-1 conversion
       bug (empty string returned) when using iconv_fallback
-      (thanks chrisØfmgp*com)
+      (thanks chrisÃ˜fmgp*com)
     * Bugfix: Missing 'lossless' key in RIFF-WAV
-      (thanks bobbfwedØcomcast*net)
+      (thanks bobbfwedÃ˜comcast*net)
 
 1.7.3: [2005-04-22] James Heinrich
-    » Added TAR support -- new file: module.archive.tar.php
-      (thanks Mike Mozolin <teddybearØmail*ru> for code!)
-    » Added GZIP support -- new file: module.archive.gzip.php
-      (thanks Mike Mozolin <teddybearØmail*ru> for code!)
+    Â» Added TAR support -- new file: module.archive.tar.php
+      (thanks Mike Mozolin <teddybearÃ˜mail*ru> for code!)
+    Â» Added GZIP support -- new file: module.archive.gzip.php
+      (thanks Mike Mozolin <teddybearÃ˜mail*ru> for code!)
     * Bugfix: demo.browse.php now displays embedded images
       internally instead of passing local filename as IMG
       SRC (should allow demo.browse.php to correctly show
       embedded images over a network)
-      (thanks patpowermanØhotmail*com)
+      (thanks patpowermanÃ˜hotmail*com)
     * Bugfix: minor UTF-8 display issues in demo.browse.php
     * Bugfix: demo.browse.php now works even if the evil
       setting magic_quotes_gpc is turned on
-      (thanks patpowermanØhotmail*com)
+      (thanks patpowermanÃ˜hotmail*com)
     * Bugfix: incorrect MIDI playtime for some files
-      (thanks joelØoneporpoise*com)
+      (thanks joelÃ˜oneporpoise*com)
     * Bugfix: 'url_source' typo in module.tag.id3v2.php
-      (thanks richardlynchØusers*sourceforge*net)
+      (thanks richardlynchÃ˜users*sourceforge*net)
     * Bugfix: Quicktime 'mvhd' matrix values were wrong
-      (thanks webØbobbymac*net)
-    ¤ ID3v2 now returns xx/yy for ['track'] (if
+      (thanks webÃ˜bobbymac*net)
+    Â¤ ID3v2 now returns xx/yy for ['track'] (if
       available), with xx in ['tracknum'] and yy in
       ['totaltracks']. Previously ['tracknum'] was not
       available and ['track'] had only xx.
@@ -632,10 +683,10 @@ Version History
 
 
 1.7.2: [2004-10-18] Allan Hansen
-    » Added support for WavPack v4.0+
-      (thanks ahØartemis*dk)
-    » Removed code for parsing EXE files
-      (thanks ahØartemis*dk)
+    Â» Added support for WavPack v4.0+
+      (thanks ahÃ˜artemis*dk)
+    Â» Removed code for parsing EXE files
+      (thanks ahÃ˜artemis*dk)
       Removed file: module.misc.exe.php
     * Bugfix: Large ID3v2 tags inside ASF not parsed
       properly under PHP5.
@@ -645,45 +696,45 @@ Version History
     * Bugfix: New iTunes crashes PHP - temp fix - no tags
       on those files.
     * Bugfix: ['nsv']['NSVs']['framerate_index'] might be
-      wrong  (thanks ahØartemis*dk)
+      wrong  (thanks ahÃ˜artemis*dk)
     * Bugfix: transparent color was wrong from truecolor
-      PNG  (thanks ahØartemis*dk)
+      PNG  (thanks ahÃ˜artemis*dk)
     * Bugfix: Changed MPC SV7 header size from 30 to 28,
       this will change hash values for MPC files
-      (thanks ahØartemis*dk)
+      (thanks ahÃ˜artemis*dk)
     * Bugfix: Changed MPC SV4-6 header size from 28 to 8,
       this will change hash values for MPC files
-      (thanks ahØartemis*dk)
-    ¤ Trim/unset wavpack encoder_options to match 2.0.0b2
+      (thanks ahÃ˜artemis*dk)
+    Â¤ Trim/unset wavpack encoder_options to match 2.0.0b2
       output.
-    ¤ Commented-out unknown/unused values in NSV and ISO
-      modules  (thanks ahØartemis*dk)
+    Â¤ Commented-out unknown/unused values in NSV and ISO
+      modules  (thanks ahÃ˜artemis*dk)
 
 
 1.7.1b1: [July-26-2004] James Heinrich
-    » Added support for Apple Lossless Audio Codec
-    » Added support for RealAudio Lossless
-    » Added support for TTA v3
-    » Added support for TIFF
+    Â» Added support for Apple Lossless Audio Codec
+    Â» Added support for RealAudio Lossless
+    Â» Added support for TTA v3
+    Â» Added support for TIFF
       New file: /getid3/module.graphic.tiff.php
-    » Modified iconv_fallback to work with UTF-8, UTF-16, UTF-16LE,
+    Â» Modified iconv_fallback to work with UTF-8, UTF-16, UTF-16LE,
       UTF-16BE and ISO-8859-1 even if iconv() and/or XML support is
       not available. This means that iconv() is no longer required
       for most users of getID3()
-      (thanks Jeremia, khleeØbitpass*com)
-    » Added support for Monkey's Audio v3.98+ (thanks ahØartemis*dk)
-    » Included new demo showing most-basic getID3() usage
+      (thanks Jeremia, khleeÃ˜bitpass*com)
+    Â» Added support for Monkey's Audio v3.98+ (thanks ahÃ˜artemis*dk)
+    Â» Included new demo showing most-basic getID3() usage
       New file: /demos/demo.basic.php
     * Bugfix: LAME3.94+ presets cached incorrectly if multiple files
       are scanned in one batch and first file is LAME3.93 or earlier
-      (thanks enoyandØyahoo*com)
+      (thanks enoyandÃ˜yahoo*com)
     * Bugfix: Added warning if compressed ID3v2 frame decompression
       fails. (thanks Mike Billings)
     * Bugfix: Assorted small fixes to ensure compatability with PHP5
     * Bugfix: ID3v1 genre "Blues" could not be written
       (thanks Jeremia)
     * Bugfix: ['bitrate_mode'] typo in module.audio-video.real.php
-      (thanks asukakenjiØusers*sourceforge*net)
+      (thanks asukakenjiÃ˜users*sourceforge*net)
     * Bugfix: ['zip']['files'] is now populated with filenames even
       if End Of Central Directory couldn't be parsed
     * Bugfix: ['audio']['lossless'] was incorrect for FLAC
@@ -692,32 +743,32 @@ Version History
       /demo/getid3.browse.php
     * Bugfix: PHP v5 compatability changes (float array keys, fread()
       calls with zero data length)
-      (thanks getid3Øjsc*pp*ru)
+      (thanks getid3Ã˜jsc*pp*ru)
     * Bugfix: was dying if on compressed ID3v2 frames if
       gzuncompress() function was unavailable
     * Bugfix: ['vqf']['COMM'] was always empty
     * Bugfix: MIDI playtime was missing for single-track MIDI files
     * Bugfix: removed &#0; characters from ['comments_html']
-      (thanks p*quaedackersØplanet*nl)
+      (thanks p*quaedackersÃ˜planet*nl)
     * Bugfix: improved MIDI playtime accuracy
-      (thanks joelØoneporpoise*com)
+      (thanks joelÃ˜oneporpoise*com)
     * Bugfix: BMP subtypes 4 and 5 were not being identified
     * Bugfix: frame_rate in AVI was incorrectly truncated to integer
     * Bugfix: FLAC cuesheet track index was incorrect
-      (thanks tetsuo*yokozukaØoperamail*com)
-    ¤ ['quicktime']['display_scale'] now contains the playback scale
+      (thanks tetsuo*yokozukaÃ˜operamail*com)
+    Â¤ ['quicktime']['display_scale'] now contains the playback scale
       multiplier for QuickTime movies - a movie set to playback at
       double-size will have "2" here. Other values are "1" and "0.5"
-    ¤ Added LAME preset guessing for --preset medium with v3.90.3
-      (thanks phwipØfish*co*uk)
-    ¤ Added $encoding_id3v1 to allow for ID3v1 encodings other than
+    Â¤ Added LAME preset guessing for --preset medium with v3.90.3
+      (thanks phwipÃ˜fish*co*uk)
+    Â¤ Added $encoding_id3v1 to allow for ID3v1 encodings other than
       the standard ISO-8859-1
-    ¤ Default AVI video bitrate_mode is now 'vbr'
-      (thanks eltoderØpisem*net)
+    Â¤ Default AVI video bitrate_mode is now 'vbr'
+      (thanks eltoderÃ˜pisem*net)
     Force getID3() to abort if Shorten files have ID3 or APE tags
-      (thanks ahØartemis*dk)
+      (thanks ahÃ˜artemis*dk)
     Editable textbox for parent directory in demo.browse.php
-      (thanks eltoderØpisem*net)
+      (thanks eltoderÃ˜pisem*net)
 
 
 1.7.0-hotfix [2004-03-17] Allan Hansen
@@ -725,7 +776,7 @@ Version History
     * Bugfix: PHP 4.1.x compatiblity - fgets($fp) => fgets($fp, 1024)
     * Bugfix: Added default charset to TextEncodingNameLookup() in
       module.tag.id3v2.php
-    Ø Removed option_no_iconv
+    Ã˜ Removed option_no_iconv
       iconv() support is only a requirement for WMA/WMW/ASF, and for
       destination encodings other than ISO-8859-1 and UTF-8, iconv is
       not needed otherwise. New 'iconv_req' in GetFileFormatArray()
@@ -735,51 +786,51 @@ Version History
 
 
 1.7.0: [January-19-2004] James Heinrich
-    » Added support for RIFF/CDXA files (MPEG video in RIFF container
-      format (thanks chrisØdigitekdesign*com)
-    » Added support for TTA v2  (thanks ahØartemis*dk)
-    ¤ ID3v2 unsynchronisation scheme disabled by default because most
+    Â» Added support for RIFF/CDXA files (MPEG video in RIFF container
+      format (thanks chrisÃ˜digitekdesign*com)
+    Â» Added support for TTA v2  (thanks ahÃ˜artemis*dk)
+    Â¤ ID3v2 unsynchronisation scheme disabled by default because most
       tag-reading programs cannot read unsynchronised tags. Can be
       overridden by setting id3v2_use_unsynchronisation to true.
-      (thanks mikeØdelusion*org)
-    ¤ extention.*.php renamed to extension.*.php
-      (thanks tp62Øcornell*edu)
-    ¤ /demo/demo.check.php renamed to /demo/demo.browse.php
-    ¤ Added id3v2_paddedlength configuration parameter to WriteTags()
+      (thanks mikeÃ˜delusion*org)
+    Â¤ extention.*.php renamed to extension.*.php
+      (thanks tp62Ã˜cornell*edu)
+    Â¤ /demo/demo.check.php renamed to /demo/demo.browse.php
+    Â¤ Added id3v2_paddedlength configuration parameter to WriteTags()
       and renamed tag_language to id3v2_tag_language
-    ¤ MPEG audio layers are now represented as 1, 2 or 3 instead of
+    Â¤ MPEG audio layers are now represented as 1, 2 or 3 instead of
       'I', 'II', or 'III'
-    ¤ Added [audio][wformattag] and [video][fourcc] for WAV and AVI
-    ¤ Added [audio][streams] which contains one entry for each audio
+    Â¤ Added [audio][wformattag] and [video][fourcc] for WAV and AVI
+    Â¤ Added [audio][streams] which contains one entry for each audio
       stream present in the file (usually only one). The data is a
       copy of what is usually found in [audio]. If there are multiple
       audio streams then [audio] will contain a sum of the bitrates
       of all audio streams, and the data format of the first stream
       (if streams are of different data types)
-    ¤ Added BruteForce mode to mp3 scanning. Disabled by default as
+    Â¤ Added BruteForce mode to mp3 scanning. Disabled by default as
       it is extremely slow and only files that are broken enough to
       not really play will gain any benefit from this.
-    ¤ Suppress '--resample xxxxx' appended to encoder options for mp3
+    Â¤ Suppress '--resample xxxxx' appended to encoder options for mp3
       with low-quality presets for default sampling frequencies
-    ¤ Enhanced LAME preset guessing for pre-3.93 with a better lookup
-      table, --resample/--lowpass guessing (thanks phwipØfish*co*uk)
-    ¤ RIFF files with non-MP3 contents no longer have
+    Â¤ Enhanced LAME preset guessing for pre-3.93 with a better lookup
+      table, --resample/--lowpass guessing (thanks phwipÃ˜fish*co*uk)
+    Â¤ RIFF files with non-MP3 contents no longer have
       [audio][encoder_options] set
-    ¤ Added [audio][encoder_options] to audio formats where possible
+    Â¤ Added [audio][encoder_options] to audio formats where possible
       (including LiteWave, LPAC, OptimFROG, TTA)
-    ¤ Moved [quantization] and [max_prediction_order] from
+    Â¤ Moved [quantization] and [max_prediction_order] from
       [lpac][flags] to just [lpac]
-    ¤ WavPack flags are now parsed into [wavpack][flags]
+    Â¤ WavPack flags are now parsed into [wavpack][flags]
     * Bugfix: APEtags with ReplayGain information stored with comma-
       seperated decimal values (ie "0,95" instead of "0.95") were
       giving wrong peak and gain values
     * Bugfix: Filesize > 2GB not always detected correctly
     * Bugfix: Some ID3v2 frames had data key unset incorrectly
-      (thanks chrisØdigitekdesign*com)
+      (thanks chrisÃ˜digitekdesign*com)
     * Bugfix: Warnings on empty-strings-only comments
     * Bugfix: ID3v2 tag writing may have had incorrect padding length
       if padded length less than current ID3v2 tag length and
-      merge_existing_data is false  (thanks mikeØdelusion*org)
+      merge_existing_data is false  (thanks mikeÃ˜delusion*org)
     * Bugfix: hash_data() for SHA1 was broken under Windows
     * Bugfix: BigEndian2Float()/LittleEndian2Float() were broken
     * Bugfix: LAME header calculated track peaks were incorrect for
@@ -797,17 +848,17 @@ Version History
     md5_file() and sha1_file() now work under Windows in PHP < 4.2.0
       and 4.3.0 respectively with helper apps
     Default md5_data() tempfile location is now system temp directory
-      instead of same directory as file (thanks towbØtiscali*de)
+      instead of same directory as file (thanks towbÃ˜tiscali*de)
     Improved list of RIFF ['INFO'] comment key translations
     More helpful error message when GETID3_HELPERAPPSDIR has spaces
     /demo/demo.browse.php now autogets both MD5 and SHA1 hashes for
       files < 50MB
     Replaced PHP_OS comparisons with GETID3_OS_ISWINDOWS define
-      (thanks necroticØusers*sourceforge*net)
+      (thanks necroticÃ˜users*sourceforge*net)
 
 
 1.7.0b5: [December-29-2003] James Heinrich
-    » Windows only: Various binary files are now required for some
+    Â» Windows only: Various binary files are now required for some
       file formats, especially for tag writing, as well as md5sum
       (and other) calculations. These binaries are now stored in the
       directory defined as GETID3_HELPERAPPSDIR in getid3.php
@@ -816,7 +867,7 @@ Version History
       All neccesary files are available as a seperate download.
       See /helperapps/readme.txt for more information
       New file: /helperapps/readme.txt
-    » Unified tag-writing interface for all tag formats
+    Â» Unified tag-writing interface for all tag formats
       New file: /getid3/write.php
                 /getid3/write.apetag.php
                 /getid3/write.id3v1.php
@@ -824,61 +875,61 @@ Version History
                 /getid3/write.lyrics3.php
                 /getid3/write.metaflac.php
                 /getid3/write.vorbiscomment.php
-    » Added support for Shorten - requires shorten binary (head.exe
+    Â» Added support for Shorten - requires shorten binary (head.exe
       is also required under Windows).
       New file: /getid3/module.audio.shorten.php
-    » Added support for RKAU
+    Â» Added support for RKAU
       New file: /getid3/module.audio.rkau.php
-    » Added (minimal) support for SZIP
+    Â» Added (minimal) support for SZIP
       New file: /getid3/module.archive.szip.php
-    » Added MySQL caching extention  (thanks ahØartemis*dk)
+    Â» Added MySQL caching extention  (thanks ahÃ˜artemis*dk)
       New file: /getid3/extention.cache.mysql.php
-    » Added DBM caching extention  (thanks ahØartemis*dk)
+    Â» Added DBM caching extention  (thanks ahÃ˜artemis*dk)
       New file: /getid3/extention.cache.dbm.php
-    » Added sha1_data hash option  (thanks ahØartemis*dk)
-    » Added option to allow getID3() to skip ID3v2 without parsing it
+    Â» Added sha1_data hash option  (thanks ahÃ˜artemis*dk)
+    Â» Added option to allow getID3() to skip ID3v2 without parsing it
       for faster scanning when ID3v2 data is not required. If you
       want to enable this feature delete /getid3/module.tag.id3v2.php
-      (thanks ahØartemis*dk)
-    ¤ 8-bit WAV data now calculates MD5 checksums as normal, not
+      (thanks ahÃ˜artemis*dk)
+    Â¤ 8-bit WAV data now calculates MD5 checksums as normal, not
       converting to signed data as before, so stored md5_data_source
       in FLAC files will no longer match md5_data for the equivalent
       decoded 8-bit WAV. A warning will be generated for 8-bit FLAC
       files
-    ¤ Added option_no_iconv option to allow getID3() to work
+    Â¤ Added option_no_iconv option to allow getID3() to work
       partially without iconv() support enabled in PHP
-      (thanks ahØartemis*dk)
-    ¤ All '*_ascii' keys removed for ASF/WMA/WMV files
-    ¤ All 'ascii*' keys removed for ID3v2 tags
-    ¤ Ogg filetypes now return MIME of "application/ogg" instead of
+      (thanks ahÃ˜artemis*dk)
+    Â¤ All '*_ascii' keys removed for ASF/WMA/WMV files
+    Â¤ All 'ascii*' keys removed for ID3v2 tags
+    Â¤ Ogg filetypes now return MIME of "application/ogg" instead of
       the previous "application/x-ogg"
-      (thanks blakewattersØusers*sourceforge*net)
-    ¤ Force contents of ['id3v2']['comments'] to UTF-8 format from
+      (thanks blakewattersÃ˜users*sourceforge*net)
+    Â¤ Force contents of ['id3v2']['comments'] to UTF-8 format from
       whatever encoding each frame may have (text encoding can vary
       from frame to frame in ID3v2)
-    ¤ MP3Gain information from APE tags suppressed from ['tags'] and
+    Â¤ MP3Gain information from APE tags suppressed from ['tags'] and
       parsed into ['replay_gain']
-    ¤ ReplayGain information (all formats) changed from "Radio" and
+    Â¤ ReplayGain information (all formats) changed from "Radio" and
       "Audiophile" to "Track" and "Album" respectively
-    ¤ ['volume'] and ['max_noclip_gain'] are now available in both
+    Â¤ ['volume'] and ['max_noclip_gain'] are now available in both
       ['replay_gain']['track'] and ['replay_gain']['album'] for all
       formats that calculate ReplayGain.
-    ¤ ['video']['total_frames'] is available for AVIs
-    ¤ All parsed ID3v2 frame data is now in ['id3v2'][XXXX][#]
+    Â¤ ['video']['total_frames'] is available for AVIs
+    Â¤ All parsed ID3v2 frame data is now in ['id3v2'][XXXX][#]
       (previously some frame types would have numeric array keys if
       multiple instances of that frame type were allowed and other
       frame types would not)
-    ¤ ASF/WMA "WM/Picture" images are now parsed in the same manner
+    Â¤ ASF/WMA "WM/Picture" images are now parsed in the same manner
       as ID3v2 with the image (ex JPEG) data returned in [data]
       rather than [value]
     * Bugfix: Optional tag processing options were being ignored (ie
       ID3v1 still processed even if option_tag_id3v1 == false)
-      (thanks ahØartemis*dk)
+      (thanks ahÃ˜artemis*dk)
     * Bugfix: fixed MultiByteCharString2HTML() for UTF-8
     * Bugfix: Quicktime files not always reporting video frame_rate
     * Bugfix: False ID3v1 synch patterns in APE or Lyrics3 tags are
       now detected and incorrect ID3v1 data not returned
-      (thanks sebastian_maresØusers*sourceforge*net for the idea)
+      (thanks sebastian_maresÃ˜users*sourceforge*net for the idea)
     * Bugfix: WMA9 Lossless now reported as lossless
     * Bugfix: two typos in ID3v1 genre list
     * Bugfix: MPEG-2/2.5 ABR/VBR MP3 files had doubled playtime
@@ -888,61 +939,61 @@ Version History
       frame length calculation (must be multiple of slot length)
     Added alternative md5_data via system call - twice as fast. Needs
       "getID3()-WindowsSupport" to work under Windows.
-      (thanks ahØartemis*dk)
+      (thanks ahÃ˜artemis*dk)
     ID3v2.4 compressed frames are now supported
     php_uname() calls changed to use PHP_OS constant
     Added SCMPX extensions to ID3v1 genres (0xF0-0xFE)
     Obfuscated contributor email address in changelog and sourcecode
     Added memory-saving EmbeddedLookup() function for lookup tables
-      in RIFF and ID3v2 modules (thanks ahØartemis*dk)
+      in RIFF and ID3v2 modules (thanks ahÃ˜artemis*dk)
     Major memory patches to many modules by using
       $var = &$INFO_ARRAY_AT_SOME_INDEX
       in place of large multi-dimensional array declarations.
       Memory saved:  RIFF: ~200kB;  ID3v2: ~475kB;  ASF: ~50kB  etc.
-      (thanks ahØartemis*dk)
+      (thanks ahÃ˜artemis*dk)
 
 
 1.7.0b4: [November-19-2003] James Heinrich
-   » Support added for MPC files with old SV4-SV6 structure
-   » RealVideo now properly supported with resolution, framerate, etc
+   Â» Support added for MPC files with old SV4-SV6 structure
+   Â» RealVideo now properly supported with resolution, framerate, etc
      (thanks jcsston)
-   » RealAudio files with old-style file format (v2-v4) are now
+   Â» RealAudio files with old-style file format (v2-v4) are now
      fully supported
-   » Support added for DolbyDigital WAV files (thanks ahØartemis*dk)
-   ¤ ['RIFF'] is now ['riff'] to conform to make all root key names
+   Â» Support added for DolbyDigital WAV files (thanks ahÃ˜artemis*dk)
+   Â¤ ['RIFF'] is now ['riff'] to conform to make all root key names
      lowercase
-   ¤ ['OFR'] is now ['ofr'] to conform to make all root key names
+   Â¤ ['OFR'] is now ['ofr'] to conform to make all root key names
      lowercase
-   ¤ ['tags_html'] is now available as a copy of ['tags'] but
+   Â¤ ['tags_html'] is now available as a copy of ['tags'] but
      with all text replaced with an HTML version of all characters
      above chr(127), translated according to whatever the encoding
      of the source tag is, in the HTML form &#1234;
-   ¤ CopyTagsToComments() is now available in getid3_lib
-   ¤ QuicktimeVR files now return a ['video']['dataformat'] of
-     'quicktimevr' instead of 'quicktime' (thanks gtsØtsu*biz)
-   ¤ Quicktime video files with DivX, Xvid, 3ivx or MPEG4 video
+   Â¤ CopyTagsToComments() is now available in getid3_lib
+   Â¤ QuicktimeVR files now return a ['video']['dataformat'] of
+     'quicktimevr' instead of 'quicktime' (thanks gtsÃ˜tsu*biz)
+   Â¤ Quicktime video files with DivX, Xvid, 3ivx or MPEG4 video
      streams now return those names as ['video']['dataformat']
-   ¤ MPEG video files are now identified with ['video']['codec'] set
+   Â¤ MPEG video files are now identified with ['video']['codec'] set
      to either 'MPEG-1' or 'MPEG-2' (rather than just 'MPEG'). If you
      see a file wrongly identified, please report it!
      (thanks fccHandler)
-   ¤ All bitrate values in ['mpeg']['audio'] is now reported in bps
+   Â¤ All bitrate values in ['mpeg']['audio'] is now reported in bps
      rather than kbps (ie 128000 instead of 128) for consistancy
-   ¤ AVIs with MP2 audio now report ['audio']['dataformat'] as 'mp2'
-     rather than 'wav'  (thanks metalbrainØnetian*com)
-   ¤ Added ['md5_data_source'] for OptimFROG
-   ¤ AC3 in RIFF-WAV now identified with ['audio']['dataformat']
+   Â¤ AVIs with MP2 audio now report ['audio']['dataformat'] as 'mp2'
+     rather than 'wav'  (thanks metalbrainÃ˜netian*com)
+   Â¤ Added ['md5_data_source'] for OptimFROG
+   Â¤ AC3 in RIFF-WAV now identified with ['audio']['dataformat']
      returning 'ac3'
-   ¤ WavPack ['extra_bc'] now returned as integer
-   ¤ WavPack ['extras'] now returned as 3-element array of integers
-   ¤ MP3 ['audio']['encoder options'] now returns 'VBR' or 'CBR' only
+   Â¤ WavPack ['extra_bc'] now returned as integer
+   Â¤ WavPack ['extras'] now returned as 3-element array of integers
+   Â¤ MP3 ['audio']['encoder options'] now returns 'VBR' or 'CBR' only
      (no bitrate) if no LAME preset is used, or 'VBR q??' where ?? is
      a number 0-100 for Fraunhofer-encoded VBR MP3s
    * Bugfix: VBR MP3s could have incorrect bitrate reported
    * Bugfix: Quicktime files with MP4 audio were not returning
-     ['video']['dataformat'] (thanks robØmassive-interactive*nl)
+     ['video']['dataformat'] (thanks robÃ˜massive-interactive*nl)
    * Bugfix: strpad vs str_pad typo in module.riff.php
-     (thanks nicojunØusers*sourceforge*net)
+     (thanks nicojunÃ˜users*sourceforge*net)
    * Bugfix: ReplayGain information was often wrong for MPC files
    * Bugfix: MD5 and other post-TAIL chunks were not being processed
      in module.audio.optimfrog.php
@@ -953,19 +1004,19 @@ Version History
      chunk
    * Bugfix: Properly handle VBR MP3s with "Info" (rather than
      "Xing") header frame. foobar2000 adds this to MP3 files when
-     "Fix MP3 Header" function is used (thanks ahØartemis*dk)
+     "Fix MP3 Header" function is used (thanks ahÃ˜artemis*dk)
    * Bugfix: Fraunhofer VBRI headers for MP3s were assuming 2-byte
      entries for TOC rather than using stride, and were ignoring the
-     scaling value. (thanks sebastianØmaresweb*net)
+     scaling value. (thanks sebastianÃ˜maresweb*net)
    Several QuickTime atoms have been added to an exclusion list
      because they have been observed, but I have no idea what they
      are supposed to do so I can't add real support for them, but
-     they should not generate warnings (robØmassive-interactive*nl)
+     they should not generate warnings (robÃ˜massive-interactive*nl)
    Old MPC encoder (before v1.06) was return as v0.00, now returned
      as 'Buschmann v1.7.0-v1.7.9 or Klemm v0.90-v1.05'
-     (thanks ahØartemis*dk)
+     (thanks ahÃ˜artemis*dk)
    Added check for magic_quotes_runtime and code to disable it if
-     neccesary (thanks stefan*kischkelØt-online*de)
+     neccesary (thanks stefan*kischkelÃ˜t-online*de)
    Added 3ivx fourCCs to module.audio-video.quicktime.php
    MP3 and AC3 streams are now parsed when contained inside RIFF-WAV
      or RIFF-AVI container formats
@@ -973,16 +1024,16 @@ Version History
 
 
 1.7.0b3: [October-17-2003] James Heinrich
-   » AC-3 (aka Dolby Digital) is now supported.
+   Â» AC-3 (aka Dolby Digital) is now supported.
      New file: /getid3/module.audio.ac3.php
    * Bugfix: ID3v2-writing function Unsynchronise() was broken, which
      made ID3v2 tag containing binary data (typically pictures) get
-     corrupted. (thanks t*coombesØbendigo*vic*gov*au,
-     i*kuehlbornØndh*net, mikeØdelusion*org, mikeØftl*com)
+     corrupted. (thanks t*coombesÃ˜bendigo*vic*gov*au,
+     i*kuehlbornÃ˜ndh*net, mikeÃ˜delusion*org, mikeÃ˜ftl*com)
    * Bugfix: Zip comments now returned as array instead of string,
      as they're supposed to be.
    * Bugfix: Quicktime/MP4 files may have reported extremely low
-     bitrates (thanks spunkØdasspunk*com)
+     bitrates (thanks spunkÃ˜dasspunk*com)
    Improved double-ID3v1 check to prevent false detection when string
      "TAG" is present in APE or Lyrics3
    Fixed /demo/simple.php
@@ -992,36 +1043,36 @@ Version History
 
 
 1.7.0b2: [October-15-2003] James Heinrich
-   » TTA Lossless Audio Compressor format now supported.
+   Â» TTA Lossless Audio Compressor format now supported.
      (http://tta.iszf.irk.ru)
      New file: /getid3/module.graphic.tta.php
-   » PhotoCD (PCD) format now supported. Image data for the three
+   Â» PhotoCD (PCD) format now supported. Image data for the three
      lowest resolutions (192x128, 384x256, 768x512) can be optionally
      extracted.
      New file: /getid3/module.graphic.pcd.php
-   ¤ RIFF-MP3 files now should return the same ['md5_data'] as the
+   Â¤ RIFF-MP3 files now should return the same ['md5_data'] as the
      identical MP3 file outside the RIFF container
-   ¤ Name of LAME preset used (if available, needs LAME v3.90+)
+   Â¤ Name of LAME preset used (if available, needs LAME v3.90+)
      returned in ['mpeg']['audio']['LAME']['preset_used'] and also as
      part of ['audio']['encoder_options']
-   ¤ VQF module now sets ['audio']['encoder_options'] to i.e. CBR96
-   ¤ MP3 module now sets ['audio']['encoder_options'] on CBR files
+   Â¤ VQF module now sets ['audio']['encoder_options'] to i.e. CBR96
+   Â¤ MP3 module now sets ['audio']['encoder_options'] on CBR files
      and all LAME-encoded files
-   ¤ MPC module now sets ['audio']['encoder_options']
-   ¤ Monkey module now sets ['audio']['encoder_options']
-   ¤ AAC module now sets ['audio']['encoder_options'] to profile name
-   ¤ ASF module now sets ['audio']['encoder_options']
-   ¤ Ogg module adds ['audio']['encoder_options'] -b 128 on
+   Â¤ MPC module now sets ['audio']['encoder_options']
+   Â¤ Monkey module now sets ['audio']['encoder_options']
+   Â¤ AAC module now sets ['audio']['encoder_options'] to profile name
+   Â¤ ASF module now sets ['audio']['encoder_options']
+   Â¤ Ogg module adds ['audio']['encoder_options'] -b 128 on
      Ogg Vorbis 1.0+ ABR files
-   ¤ Ogg module adds ['audio']['encoder_options'] -q N   on
+   Â¤ Ogg module adds ['audio']['encoder_options'] -q N   on
      Ogg Vorbis 1.0+ VBR files 44k/48k sample rate/stereo files only.
-   ¤ Ogg module ['audio']['encoder_options'] "Nominal birate: 80k" to
+   Â¤ Ogg module ['audio']['encoder_options'] "Nominal birate: 80k" to
      other Ogg Vorbis files.
-   ¤ ID3v2 track number now returned as string (with leading zeros,
+   Â¤ ID3v2 track number now returned as string (with leading zeros,
      if present in data) rather than integer (thanks Plamen)
-   ¤ ASF module returns ['asf']['comments']['encoding_time_unix'] if
+   Â¤ ASF module returns ['asf']['comments']['encoding_time_unix'] if
      available (from WM/EncodingTime)
-   ¤ Fixed /demo/mysql.php and added some new features:
+   Â¤ Fixed /demo/mysql.php and added some new features:
      - encoder options
      - ID3v2 "Encoded By"
      - non-empty comments
@@ -1045,10 +1096,10 @@ Version History
    * Bugfix: NSV module died in 1.7.0b1
    * Bugfix: ASF module died in 1.7.0b1 when WM/Picture preset
    * Bugfix: ASF tracknumber incorrect when specified by WM/Track
-     rather than WM/TrackNumber (thanks jgriffiniiiØhotmail*com)
+     rather than WM/TrackNumber (thanks jgriffiniiiÃ˜hotmail*com)
    * Bugfix: MPEG audio+video playtime should now be pretty accurate
      (ie within 0.1% variation at most)
-     (thanks mgrimmØhealthtvchannel*org)
+     (thanks mgrimmÃ˜healthtvchannel*org)
    * Bugfix: ID3v2 not being copied to ['tags'] in some cases
    * Bugfix: LAME CBR files with Info tag were being incorrectly
      flagged as VBR (thanks Jojo)
@@ -1057,7 +1108,7 @@ Version History
      reliable/accurate pattern matching
    Added duplicate-ID3v1 tag checking (two ID3v1 tags, one after the
      other) that has been known to occur with iTunes
-     (thanks towbØtiscali*de)
+     (thanks towbÃ˜tiscali*de)
    Added instructions for enabling iconv() support under Windows
    Removed some unneccesary debugging code
    Suppressed duplicate PHP warnings for missing include files
@@ -1067,7 +1118,7 @@ Version History
 
 1.7.0b1: [2003-09-28] Allan Hansen
    This beta version was not made by James Heinrich. It was made by
-   Allan Hansen <ahØartemis*dk> - please send bug reports on this
+   Allan Hansen <ahÃ˜artemis*dk> - please send bug reports on this
    beta directly to me.
 
    James Heinrich will release 1.7.0 final, but it may take some time
@@ -1082,8 +1133,8 @@ Version History
    prepended by GETID3_. It declares no global scope functions - they
    are all wrapped into classes.
 
-   » Made getID3() depend on iconv library: compile PHP --with-iconv
-   » Created new directory structure
+   Â» Made getID3() depend on iconv library: compile PHP --with-iconv
+   Â» Created new directory structure
        Moved all demos to demos/
        Moved all getID3() files to getid3/
        Renamed most files to module.something
@@ -1092,23 +1143,23 @@ Version History
        Wrapped all modules into classes
    * Bugfix: Implemented misc patches from Eugene Toder
    * Bugfix: Implemented misc patches from "six"
-   ¤ Added root key 'encoding'
-   ¤ Added prefix GETID3_ to all defined constants.
-   ¤ Wrapped getid3.php into getid3 class
-   ¤ Wrapped getid3.functions.php into getid3_lib class
+   Â¤ Added root key 'encoding'
+   Â¤ Added prefix GETID3_ to all defined constants.
+   Â¤ Wrapped getid3.php into getid3 class
+   Â¤ Wrapped getid3.functions.php into getid3_lib class
        Removed unused functions
        Moved several functions away from getid3.functions.php and
          into the files where they are actually used.
        Renamed getid3.functions.php to getid3.lib.php
        Moved getid3.rgad.php functions into getid3_lib
        Moved getid3.getimagesize.php funcitons ingo getid3_lib
-   ¤ Moved getid3.ogginfo.php into ogg module
-   ¤ Combined GetTagOnly() and GetAllFileInfo() in method analyze
-   ¤ Removed redundant and unuseful root keys
+   Â¤ Moved getid3.ogginfo.php into ogg module
+   Â¤ Combined GetTagOnly() and GetAllFileInfo() in method analyze
+   Â¤ Removed redundant and unuseful root keys
        'file_modified_time' == filemtime($filename)
        'md5_file' == md5_file($filename)
        'exist' == file_exists($filename)
-   ¤ Changed root key ['tags'] from array of string to array of array
+   Â¤ Changed root key ['tags'] from array of string to array of array
      of comments.
    Simplified code for detecting base path.
    Removed ob_ from InitializeFilepointerArray(). That was really a
@@ -1146,14 +1197,14 @@ Version History
 
 
 1.6.5: [October-06-2003] James Heinrich
-   » Added support for LiteWave (thanks supportØclearjump*com)
-   Ø Split out speedup info from ['OFR']['OFR']['compression'] into
+   Â» Added support for LiteWave (thanks supportÃ˜clearjump*com)
+   Ã˜ Split out speedup info from ['OFR']['OFR']['compression'] into
      ['OFR']['OFR']['speedup']
-   Ø If EXIF functions for JPEG not available, now warning not error
-   Ø ID3v2 track number now returned as string (with leading zeros,
+   Ã˜ If EXIF functions for JPEG not available, now warning not error
+   Ã˜ ID3v2 track number now returned as string (with leading zeros,
      if present in data) rather than integer (thanks Plamen)
    * Bugfix: now correctly parses cbSize element of WAVEFORMATEX
-     structure (thanks supportØclearjump*com)
+     structure (thanks supportÃ˜clearjump*com)
    * Bugfix: ASF module now reads non-standard field names,
      i.e. "date" as well as WM/Year - patch from Eugene Toder.
    * Bugfix: ASF module now returns genre as-is if it is not a
@@ -1162,63 +1213,63 @@ Version History
      (thanks WaldoMonster)
    Prevent infinite loop in MP3 histogram if framelength == 0
    Added wFormatTag values 0x00FF and 0x2001 - 0x2005
-     (thanks steveØheadbands*com)
+     (thanks steveÃ˜headbands*com)
    Added "twos" and "sowt" FourCCs for Mac AIFC
 
 
 1.6.4: [June-30-2003] James Heinrich
-   » Added support for free-format MP3s
+   Â» Added support for free-format MP3s
      (thanks Sebastian Mares for the idea)
-   » Compressed (Flash 6+) SWF files are now handled properly
-     (thanks alan*cheungØalumni*ust*hk)
-   » Added DeleteLyrics3() to getid3.lyrics3.php
-   » Added FixID3v1Padding() to getid3.putid3.php
-   » Added new simple MP3-splicing sample file
-     (thanks tommybobØmailandnews*com for the idea)
+   Â» Compressed (Flash 6+) SWF files are now handled properly
+     (thanks alan*cheungÃ˜alumni*ust*hk)
+   Â» Added DeleteLyrics3() to getid3.lyrics3.php
+   Â» Added FixID3v1Padding() to getid3.putid3.php
+   Â» Added new simple MP3-splicing sample file
+     (thanks tommybobÃ˜mailandnews*com for the idea)
      New file: getid3.demo.joinmp3.php
-   » Moved all contents of getid3.putid3.php into either
+   Â» Moved all contents of getid3.putid3.php into either
      getid3.id3v1.php or getid3.id3v2.php or getid3.functions.php as
      appropriate
      Removed file: getid3.putid3.php
-   ¤ ['error'] and ['warning'] keys now return as arrays, not strings
-   ¤ New root key for all files: ['file_modified_time'] (UNIX time)
-   ¤ getid3.demo.scandir.php renamed to getid3.demo.mysql.php
-   ¤ New demo file returns the MIME type only for a single file
-     (thanks adminØe-tones*co*uk for the idea)
+   Â¤ ['error'] and ['warning'] keys now return as arrays, not strings
+   Â¤ New root key for all files: ['file_modified_time'] (UNIX time)
+   Â¤ getid3.demo.scandir.php renamed to getid3.demo.mysql.php
+   Â¤ New demo file returns the MIME type only for a single file
+     (thanks adminÃ˜e-tones*co*uk for the idea)
      New file: getid3.demo.mimeonly.php
-   ¤ Added check for valid ID3v1 padding (strings should be padded
+   Â¤ Added check for valid ID3v1 padding (strings should be padded
      with null characters but some taggers incorrectly use spaces).
      A warning will be generated if padding is invalid. New boolean
      key ['id3v1']['padding_valid'] indicates padding validity.
-   ¤ CleanUpGetAllMP3info() removes more useless root keys for
+   Â¤ CleanUpGetAllMP3info() removes more useless root keys for
      unknown-format files
-   ¤ Extended LAME information in ['mpeg']['audio']['LAME'] is now
+   Â¤ Extended LAME information in ['mpeg']['audio']['LAME'] is now
      only returned for LAME v3.90+
-   ¤ LAME-encoded MP3s now return
+   Â¤ LAME-encoded MP3s now return
      ['mpeg']['audio']['LAME']['long_version'] as well as
      ['mpeg']['audio']['LAME']['short_version'] - these are identical
      in LAME v3.90+ but older versions will report longer more
      detailed version information if available
-   ¤ New Lyrics3 values: ['lyrics3']['raw']['offset_start'] and
+   Â¤ New Lyrics3 values: ['lyrics3']['raw']['offset_start'] and
      ['lyrics3']['raw']['offset_end']
-   ¤ New optional parameter on getAPEtagFilepointer() to scan from a
+   Â¤ New optional parameter on getAPEtagFilepointer() to scan from a
      defined offset rather than end-of-file to allow scanning of APE
      tags before Lyrics3 tags
-   ¤ ['tag_offset_start'] and ['tag_offset_end'] are now present in
+   Â¤ ['tag_offset_start'] and ['tag_offset_end'] are now present in
      ['ape'], ['lyrics3'], ['id3v1'] and ['id3v2']
-   ¤ Numerous changes to the returned structure and content for La
+   Â¤ Numerous changes to the returned structure and content for La
      files, including parsing the seektable (if applicable) and
      parsing RIFF data occuring after the end of the compressed audio
      data (notably RIFF comments)
-     (thanks mikeØbevin*de)
-   ¤ getSWFHeaderFilepointer() now has optional 3rd parameter
+     (thanks mikeÃ˜bevin*de)
+   Â¤ getSWFHeaderFilepointer() now has optional 3rd parameter
      $ReturnAllTagData (default == false) which if set to true will
      return data on all tags in ['swf']['tags']
-   ¤ ['swf']['bgcolor'] now returns the 6-character string
+   Â¤ ['swf']['bgcolor'] now returns the 6-character string
      representing the background color in HTML hex color format
-     (thanks ubergeekØubergeek*tv)
-   ¤ ['swf']['header']['frame_delay'] is no longer returned
-   ¤ getQuicktimeHeaderFilepointer() now has two additional optional
+     (thanks ubergeekÃ˜ubergeek*tv)
+   Â¤ ['swf']['header']['frame_delay'] is no longer returned
+   Â¤ getQuicktimeHeaderFilepointer() now has two additional optional
      parameters: $ReturnAtomData (default == true) and
      $ParseAllPossibleAtoms (default == false). Setting
      $ReturnAtomData to false will reduce the size of the returned
@@ -1227,15 +1278,15 @@ Version History
      of several atom types that contain very large tables of data
      that are not typically useful. Atom type suppressed are:
      stts, stss, stsc, stsz, and stco
-     (thanks ubergeekØubergeek*tv)
-   ¤ ['fileformat'] no longer set to 'id3' if ID3v1 or ID3v2 tag
+     (thanks ubergeekÃ˜ubergeek*tv)
+   Â¤ ['fileformat'] no longer set to 'id3' if ID3v1 or ID3v2 tag
      detected but no other data format recognized
    * Bugfix: La files now return the correct values for
      ['avdataoffset'] and ['avdataend'] and therefore the correct
      values for ['md5_data'] - note that ['md5_data'] values will not
      match values from previous versions of getID3() - the previous
      versions were incorrect
-     (thanks mikeØbevin*de)
+     (thanks mikeÃ˜bevin*de)
    * Bugfix: A temporary file was being created in the web server's
      root directory (not DocumentRoot) each time ['md5_data'] was
      calculated, and not removed due to lack of permissions. Temp
@@ -1243,22 +1294,22 @@ Version History
      of the file being examined, or the system temp directory, and
      properly removed when done.
    * Bugfix: Several incorrect values were being returned inside
-     ['mpeg']['audio']['LAME'] (thanks bouvigneØmp3-tech*org)
+     ['mpeg']['audio']['LAME'] (thanks bouvigneÃ˜mp3-tech*org)
    * Bugfix: SWF frame rates values were usually incorrect.
-     (thanks alan.cheungØalumni*ust*hk and ubergeekØubergeek*tv)
+     (thanks alan.cheungÃ˜alumni*ust*hk and ubergeekÃ˜ubergeek*tv)
    * Bugfix: ID3v2.2 files always flagged 4 bytes of invalid padding
-     (thanks marcaØmac*com)
+     (thanks marcaÃ˜mac*com)
    * Bugfix: Lyrics3 without ID3v1 was not working properly
    * Bugfix: Lyrics3, APE & ID3v1 can all now exist in the same file.
      A warning is issued if APE comes after Lyrics3 (because Lyrics3-
      aware taggers probably are not APE-aware and therefore won't be
-     able to find the Lyrics3 tag)  (thanks mp3gainØhotmail*com)
+     able to find the Lyrics3 tag)  (thanks mp3gainÃ˜hotmail*com)
    * Bugfix: WriteAPEtag() now writes the APE tag before any Lyrics3
      tags (if present) and removes any incorrect ones that are after
-     existing Lyrics3 tags  (thanks mp3gainØhotmail*com)
+     existing Lyrics3 tags  (thanks mp3gainÃ˜hotmail*com)
    * Bugfix: RIFF-WAVE file with incorrect NumberOfSamples values in
      the 'fact' chunk no longer cause incorrect playtime calculation
-     (thanks stprasadØindusnetworks*com)
+     (thanks stprasadÃ˜indusnetworks*com)
    * Bugfix: getid3.demo.simple.php had undefined variables if the
      file needed to be deep-scanned with assumeFormat
    * Bugfix: fixed previously-incorrect ['avdataend'] values for APE
@@ -1269,7 +1320,7 @@ Version History
    Truncated AVIs and WAVs are now reported
    Number of new features and bugfixes in getid3.demo.mysql.php
    Quicktime 'meta' atoms now parsed, so Quicktime MP4 files can now
-     return artist, title, album, etc  (thanks spunkØdasspunk*com)
+     return artist, title, album, etc  (thanks spunkÃ˜dasspunk*com)
    Consolidated all comments processing functions (processing the
      ['comments'] and ['tags'] keys) into HandleAllTags() which now
      also checks to ensure that APE tags are really better than ID3v2
@@ -1292,42 +1343,42 @@ Version History
 
 
 1.6.3: [May-17-2003] James Heinrich
-   » Added support for Bonk  (thanks ahØartemis*dk)
+   Â» Added support for Bonk  (thanks ahÃ˜artemis*dk)
      New file: getid3.bonk.php
-   » Added support for AVR  (thanks ahØartemis*dk)
+   Â» Added support for AVR  (thanks ahÃ˜artemis*dk)
      New file: getid3.avr.php
-   ¤ Contents of getid3.id3.php moved to getid3.id3v1.php
+   Â¤ Contents of getid3.id3.php moved to getid3.id3v1.php
      Removed file: getid3.id3.php
-   ¤ Contents of getid3.frames.php moved to getid3.id3v2.php
+   Â¤ Contents of getid3.frames.php moved to getid3.id3v2.php
      Removed file: getid3.frames.php
-   ¤ Returned data structure documentation improved and updated and
+   Â¤ Returned data structure documentation improved and updated and
      now stored in getid3.structure.txt rather than getid3.readme.txt
      New file: getid3.structure.txt
-   ¤ Now including the GNU General Public License in the distribution
+   Â¤ Now including the GNU General Public License in the distribution
      as getid3.license.txt
      New file: getid3.license.txt
-   ¤ Added new, optional, parameter to WriteAPEtag() (and also
+   Â¤ Added new, optional, parameter to WriteAPEtag() (and also
      GenerateAPEtag()) which must be set to TRUE if the values you
      are passing are already UTF8-encoded, otherwise all data is
      encoded to UTF8 by default. For all ASCII/ANSI data this value
      should be left at the defaul value of FALSE.
-   ¤ Added third, optional, parameter to getID3v2Filepointer() -
+   Â¤ Added third, optional, parameter to getID3v2Filepointer() -
      $StartingOffset (default == 0) which can parse an ID3v2 tag
      in a file at a position other than the start-of-file.
-   ¤ ['video']['pixel_aspect_ratio'] now returned when known
-   ¤ AVI files with WMA audio now return ['audio']['dataformat']
+   Â¤ ['video']['pixel_aspect_ratio'] now returned when known
+   Â¤ AVI files with WMA audio now return ['audio']['dataformat']
      of 'wma' rather than 'wav'
-   ¤ ASF-WMA files now return the artist value from WM/AlbumArtist
-     in ['comments']['artist']  (thanks msibbaldØsaebauld*com)
-   ¤ ASF-WMA files now return the 'author' value from
+   Â¤ ASF-WMA files now return the artist value from WM/AlbumArtist
+     in ['comments']['artist']  (thanks msibbaldÃ˜saebauld*com)
+   Â¤ ASF-WMA files now return the 'author' value from
      ['asf']['content_description'] in ['comments']['artist']
      instead of ['comments']['author']
-   ¤ ASF-WMA files now return the 'description' value from
+   Â¤ ASF-WMA files now return the 'description' value from
      ['asf']['content_description'] in ['comments']['comment']
      instead of ['comments']['description']
    * Bugfix: APE tag writing with multiple values for a tag (more
      than one ARTIST for example) was not being correctly written
-     (thanks ahØartemis*dk)
+     (thanks ahÃ˜artemis*dk)
    * Bugfix: CreateDeepArray() was returning an empty-string key as
      the top-level returned value - ['iso']['files'] now directly
      contains the file listing without an empty array in between.
@@ -1337,7 +1388,7 @@ Version History
      each item (title, artist, etc) with no data
    * Bugfix: APE tag writing was not UTF8-encoding the data -
      non-ASCII characters (above chr(127)) were being incorrectly
-     stored  (thanks ahØartemis*dk)
+     stored  (thanks ahÃ˜artemis*dk)
    * Bugfix: getid3.demo.scandir.php had undefined function error
    * Bugfix: getid3.demo.scandir.php would not display list of files
      with no tags
@@ -1346,63 +1397,63 @@ Version History
 
 
 1.6.2: [May-04-2003] James Heinrich
-   » New official mirror site for getID3() - http://www.getid3.org
-   » Added basic support for SWF (Flash)  (thanks n8n8Øyahoo*com)
+   Â» New official mirror site for getID3() - http://www.getid3.org
+   Â» Added basic support for SWF (Flash)  (thanks n8n8Ã˜yahoo*com)
      New file: getid3.swf.php
-   » Added experimental support for parsing the audio portion of
+   Â» Added experimental support for parsing the audio portion of
      MPEG-video files. I don't have any actual documentation for
      this, so this part is experimental and not guaranteed accurate,
      but it seems to be working OK as far as I have been able to test
      it. Bug reports (or even better - documentation!) are welcome at
      info@getid3.org
-   » Added new simple directory-scanning sample file
+   Â» Added new simple directory-scanning sample file
      New file: getid3.demo.simple.php
-   » getid3.demo.write.php now writes APE tags as well.
-   ¤ Renamed getid3.write.php to getid3.demo.write.php
-   ¤ Renamed audioinfo.class.php to getid3.demo.audioinfo.class.php
-   ¤ getid3.php now automatically includes the getid3.functions.php
+   Â» getid3.demo.write.php now writes APE tags as well.
+   Â¤ Renamed getid3.write.php to getid3.demo.write.php
+   Â¤ Renamed audioinfo.class.php to getid3.demo.audioinfo.class.php
+   Â¤ getid3.php now automatically includes the getid3.functions.php
      function library file, no need to include it seperately.
-   ¤ getLyrics3Filepointer() has been changed to be consistant with
+   Â¤ getLyrics3Filepointer() has been changed to be consistant with
      all the other similar function structures - the parameters have
      changed. The old function has been renamed to getLyrics3Data()
-   ¤ Added DeleteAPEtag() function to getid3.ape.php
-   ¤ HandleID3v1Tag() now only handles ID3v1. Lyrics3 processing is
+   Â¤ Added DeleteAPEtag() function to getid3.ape.php
+   Â¤ HandleID3v1Tag() now only handles ID3v1. Lyrics3 processing is
      now done by HandleLyrics3Tag()
-   ¤ If BitrateHistogram is enabled in getOnlyMPEGaudioInfo() it now
+   Â¤ If BitrateHistogram is enabled in getOnlyMPEGaudioInfo() it now
      also returns ['mpeg']['audio']['version_distribution'] showing
      the number of frames of each MPEG version (1, 2 or 2.5) - all
      frames *should* be of the same MPEG version
-   ¤ getID3v1Filepointer() always returns TRUE now, even if it didn't
+   Â¤ getID3v1Filepointer() always returns TRUE now, even if it didn't
      find a valid ID3v1 tag
-   ¤ getOnlyMPEGaudioInfo() now looks for MPEG sync in the first 128k
+   Â¤ getOnlyMPEGaudioInfo() now looks for MPEG sync in the first 128k
      bytes rather than the first 64k bytes
-   ¤ Added dummy function GetAllMP3info() to generate warning not to
+   Â¤ Added dummy function GetAllMP3info() to generate warning not to
      use that deprecated function.
-   ¤ ['video']['codec'] is now 'MPEG' for all MPEG video files (this
+   Â¤ ['video']['codec'] is now 'MPEG' for all MPEG video files (this
      will change to 'MPEG-1' or 'MPEG-2' as soon as I figure out how
-     to determine that)  (thanks jigalØspill*nl)
-   ¤ ['mpeg']['audio']['LAME']['mp3_gain'] renamed to
+     to determine that)  (thanks jigalÃ˜spill*nl)
+   Â¤ ['mpeg']['audio']['LAME']['mp3_gain'] renamed to
      ['mpeg']['audio']['LAME']['mp3_gain_db'] (gain in dB)
-   ¤ Added ['mpeg']['audio']['LAME']['mp3_gain_factor'] (gain as a
+   Â¤ Added ['mpeg']['audio']['LAME']['mp3_gain_factor'] (gain as a
      multiplication factor)
-   ¤ Added support for Preset and Surround Info bytes from LAME VBR
+   Â¤ Added support for Preset and Surround Info bytes from LAME VBR
      tag (http://gabriel.mp3-tech.org/mp3infotag.html)
    * Bugfix: APE tag writing would put the string 'Array' for all
-     values rather than the actual data  (thanks ahØartemis*dk)
+     values rather than the actual data  (thanks ahÃ˜artemis*dk)
    * Bugfix: Warning now generated for VBR MPEG-video files because
      getID3() cannot determine average bitrate. If you know of
      documentation that would tell me how to do this, please email
      info@getid3.org
    * Bugfix: Replay Gain values from Vorbis comments are now
      returned in ['replay_gain'] (and not in ['comments'])
-     (thanks ahØartemis*dk)
+     (thanks ahÃ˜artemis*dk)
    * Bugfix: Replay Gain values from APE comments are now correctly
-     returned in ['replay_gain']  (thanks ahØartemis*dk)
+     returned in ['replay_gain']  (thanks ahÃ˜artemis*dk)
    * Bugfix: getid3.demo.check.php is now case-insensitive when
      assuming a format for a corrupted file if standard detection
      does not identify the file type.
    * Bugfix: RIFF comments were overwriting/suppressing ID3 comments
-     for RIFF-MP3 files  (thanks wmØwofuer*com)
+     for RIFF-MP3 files  (thanks wmÃ˜wofuer*com)
    * Bugfix: RIFF-MP3 files with 'RMP3' chunks instead of 'WAVE' were
      not being correctly identified.
    * Bugfix: ID3v2 padding shorter than the length of an ID3v2 frame
@@ -1416,7 +1467,7 @@ Version History
    * Bugfix: ASF files were not always showing correct audio datatype
    * Bugfix: array_merge_clobber() and array_merge_noclobber() were
      not being conditionally defined in getid3.functions.php
-     (thanks rich.martinØreden-anders*com)
+     (thanks rich.martinÃ˜reden-anders*com)
    * Bugfix: stream_numbers was not being correctly returned in
      bitrate_mutual_exclusion_object chunks of ASF files
    * Bugfix: Added support for 24kHz and 12kHz audio in ASF files
@@ -1424,9 +1475,9 @@ Version History
      cannot find synch before end of file
    * Bugfix: Removed potential out-of-memory crash situation when
      parsing Real files with chunks larger than the available memory
-     (thanks jigalØspill*nl)
+     (thanks jigalÃ˜spill*nl)
    * Bugfix: ID3v1 was incorrectly taking precedence over ID3v2 in
-     the ['comments'] array (thanks lionelflØwanadoo*fr)
+     the ['comments'] array (thanks lionelflÃ˜wanadoo*fr)
    * Bugfix: No longer calculates overall bitrate and playtime for
      VBR MPEG video files based on the audio bitrate.
    * Bugfix: AssumeFormat was not working properly
@@ -1447,37 +1498,37 @@ Version History
    HTML colors in getid3.demo.check.php are now defined as constant
      variables at the top of the file (if you want to change them)
    Added support for OptimFROG v4.50x (non-alpha) (new header fields)
-     (thanks floringhidoØyahoo*com)
-   Added support for Lossless Audio v0.4 (thanks mikeØbevin*de)
+     (thanks floringhidoÃ˜yahoo*com)
+   Added support for Lossless Audio v0.4 (thanks mikeÃ˜bevin*de)
 
 
 1.6.1: [March-03-2003] James Heinrich
-   » Added support for writing APE v2.
+   Â» Added support for writing APE v2.
      WriteAPEtag() in getid3.ape.php
      NOTE: APE v1 writing support will *not* be added to future
      versions of getID3()
-     (thanks ahØartemis*dk and adamØphysco*com for the idea)
-   » Added support for AIFF (Audio Interchange File Format) including
-     AIFF, AIFC and 8SVX  (thanks ahØartemis*dk for the idea)
+     (thanks ahÃ˜artemis*dk and adamÃ˜physco*com for the idea)
+   Â» Added support for AIFF (Audio Interchange File Format) including
+     AIFF, AIFC and 8SVX  (thanks ahÃ˜artemis*dk for the idea)
      Removed file: getid3.aiff.php
-   » Added support for OptimFROG (v4.50a and v4.2x)
-     (thanks ahØartemis*dk for the idea)
+   Â» Added support for OptimFROG (v4.50a and v4.2x)
+     (thanks ahÃ˜artemis*dk for the idea)
      New file: getid3.optimfrog.php
-   » Added support for WavPack  (thanks ahØartemis*dk for the idea)
-   » Added support for LPAC  (thanks ahØartemis*dk for the idea)
-   » Added support for NeXT/Sun .au format
+   Â» Added support for WavPack  (thanks ahÃ˜artemis*dk for the idea)
+   Â» Added support for LPAC  (thanks ahÃ˜artemis*dk for the idea)
+   Â» Added support for NeXT/Sun .au format
      New file: getid3.au.php
-   » Added support for Creative SoundBlaster VOC format
+   Â» Added support for Creative SoundBlaster VOC format
      New file: getid3.voc.php
-   » Added support for the BWF (Broadcast Wave File) RIFF chunks
-     "bext" and "MEXT"  (thanks Ryan and njhØsurgeradio*co*uk)
-   » Added support for the CART (Broadcast Wave File) RIFF chunks
+   Â» Added support for the BWF (Broadcast Wave File) RIFF chunks
+     "bext" and "MEXT"  (thanks Ryan and njhÃ˜surgeradio*co*uk)
+   Â» Added support for the CART (Broadcast Wave File) RIFF chunks
      (thanks Ryan)
-   » Added getid3.demo.scandir.php - a sample recursive scanning demo
+   Â» Added getid3.demo.scandir.php - a sample recursive scanning demo
      that scans every file in a given directory, and all sub-
      directories, and stores the resulting data in MySQL database,
      and then displays a list of duplicate files based on md5_data
-   ¤ ['md5_data_source'] now contains the MD5 value for the original
+   Â¤ ['md5_data_source'] now contains the MD5 value for the original
      uncompressed data for formats that store that information
      (currently only FLAC v0.5+). ['md5_data'] (if chosen to be
      calculated) will contain the calculated MD5 value for the
@@ -1488,59 +1539,59 @@ Version History
      of two files is identical, even if comments or even the
      container file format is different (MP3 in RIFF container,
      FLAC in Ogg container, etc): compare ['md5_data'].
-   ¤ ['md5_data'] for 8-bit WAV files is now calculated based on a
+   Â¤ ['md5_data'] for 8-bit WAV files is now calculated based on a
      converted version of the data from unsigned to signed (MSB
      inverted) to match the MD5 value calculated by FLAC
-   ¤ New optional parameter added to GetAllFileInfo() -
+   Â¤ New optional parameter added to GetAllFileInfo() -
      $MD5dataIfMD5SourceKnown (default: false). If false the md5_data
      value will NOT be calculated for files (such as FLAC) that have
      ['md5_data_source'] set, even if $MD5data == true.
-     (thanks ahØartemis*dk)
-   ¤ getid3.check.php renamed to getid3.demo.check.php
-   ¤ Added GetTagOnly() function to getid3.php - similar to
+     (thanks ahÃ˜artemis*dk)
+   Â¤ getid3.check.php renamed to getid3.demo.check.php
+   Â¤ Added GetTagOnly() function to getid3.php - similar to
      GetAllFileInfo() except only takes a filename as a parameter and
      only returns ID3v2, APE, Lyrics3 and ID3v1 tag information - no
      attempt is made to parse the data contents of the file at all.
      (thanks Phil for the idea)
-   ¤ Added ['audio']['lossless'] and ['video']['lossless'] for all
+   Â¤ Added ['audio']['lossless'] and ['video']['lossless'] for all
      formats (when known). Both are boolean values - true means the
      data is lossless-compressed, false means the data is lossy-
      compressed.
-   ¤ Added ['audio']['compression_ratio'] and/or
+   Â¤ Added ['audio']['compression_ratio'] and/or
      ['video']['compression_ratio'] for all formats. Returns a number
      (usually) less than 1, where 1 represents no compression and 0.5
      represents a compressed file half the size of the original file
-   ¤ Added ['video']['bits_per_sample'] to all video formats (when
+   Â¤ Added ['video']['bits_per_sample'] to all video formats (when
      known)
-   ¤ Added ['video']['frame_rate'] to all video formats (when known)
-   ¤ ['fileformat'] set to 'mp1' or 'mp2' instead of 'mp3' when
-     ['audio']['dataformat'] is one of those  (thanks ahØartemis*dk)
-   ¤ Added 4th parameter to md5_data(), $invertsign, which will invert
+   Â¤ Added ['video']['frame_rate'] to all video formats (when known)
+   Â¤ ['fileformat'] set to 'mp1' or 'mp2' instead of 'mp3' when
+     ['audio']['dataformat'] is one of those  (thanks ahÃ˜artemis*dk)
+   Â¤ Added 4th parameter to md5_data(), $invertsign, which will invert
      the MSB of each byte before MD5'ing. This is needed for 8-bit
      WAV files because FLAC calculates the stored MD5 value on
      signed data rather than the original byte values. ['md5_data']
      of an 8-bit WAV will now match the ['md5_data_source'] value
-     (thanks lichvarmØphoenix*inf*upol*cz)
-   ¤ ['ape']['items']['data'] and ['ape']['items']['data_ascii'] now
+     (thanks lichvarmÃ˜phoenix*inf*upol*cz)
+   Â¤ ['ape']['items']['data'] and ['ape']['items']['data_ascii'] now
      contains an array of values, if the tag contains UTF-8 text (as
      opposed to binary data)
-   ¤ ['mpeg']['audio']['bitratemode'] renamed to
+   Â¤ ['mpeg']['audio']['bitratemode'] renamed to
      ['mpeg']['audio']['bitrate_mode']
    * Bugfix: Removed potential bug that could replace all MP3 file
      contents with only the new ID3v2 tag in getid3.putid3.php
    * Bugfix: md5_data values calculated for RIFF (WAV, AVI) files
-     were incorrect  (thanks ahØartemis*dk)
+     were incorrect  (thanks ahÃ˜artemis*dk)
    * Bugfix: MP3 data in an MP4 wrapper fileformat could not identify
-     bitrate  (thanks ahØartemis*dk)
+     bitrate  (thanks ahÃ˜artemis*dk)
    * Bugfix: ['audio'] and/or ['video'] keys would sometimes get
      removed even if not empty
    * Bugfix: Prevented creation of null entries in
      ['RIFF']['WAVE']['INFO'] if a comment entry was not present
    * Bugfix: Potential infinite-loop condition in getid3.ogg.php
-     (thanks afshin.behniaØsbcglobal*net)
+     (thanks afshin.behniaÃ˜sbcglobal*net)
    * Bugfix: Ogg files with illegal ID3v1 (and/or APE or Lyrics3)
      tags were not finding the last Ogg page
-     (thanks afshin.behniaØsbcglobal*net)
+     (thanks afshin.behniaÃ˜sbcglobal*net)
    * Bugfix: replay-gain values not properly set from LAME tag
    * Bugfix: RIFF-MP3 had incorrect md5_data
    * Bugfix: the LAME DLL CBR problem of not re-writing the LAME
@@ -1551,7 +1602,7 @@ Version History
    * Bugfix: fixed condition where APE tag with no ID3v1 tag could be
      mistaken for APE tag with ID3v1 (and incorrectly parsed)
    * Bugfix: added warning if ID3v2 frame has zero-length data
-     (thanks cmassetØclubinternet*fr)
+     (thanks cmassetÃ˜clubinternet*fr)
    * Bugfix: getid3.frames.php looking for non-existant key in USER
      frames
    Improved detection of RIFF-MP3 data. [unknown program] encodes
@@ -1561,7 +1612,7 @@ Version History
      for RIFF-WAV files with an INFO.ISFT chunk
    Generate a warning for FLAC files encoded with v0.3 or v0.4
      because audio_signature is not calculated during encoding
-     (thanks ahØartemis*dk)
+     (thanks ahÃ˜artemis*dk)
    Modified getid3.check.php to display md5_data_source as well as
      md5_file and md5_data if display-MD5 mode is selected
    Modified getid3.check.php to assume-format based on file extension
@@ -1573,10 +1624,10 @@ Version History
 
 
 1.6.0: [January-30-2003] James Heinrich
-   » Added support for OggFLAC (FLAC data stored in an Ogg container)
-     (thanks ahØartemis*dk for the idea)
-   » Added support for Speex (the data stored in an Ogg container)
-   » Comments are now available in the root 2-dimensional array
+   Â» Added support for OggFLAC (FLAC data stored in an Ogg container)
+     (thanks ahÃ˜artemis*dk for the idea)
+   Â» Added support for Speex (the data stored in an Ogg container)
+   Â» Comments are now available in the root 2-dimensional array
      ['comments'] - each entry in this array will contain one or more
      strings. For example, if there are two artists then
      ['comments']['artist'][0] will contain the first one and
@@ -1595,12 +1646,12 @@ Version History
      in APE, it will be included in the ['comments'] array).
      Note: Root keys (['title'], ['artist'], etc) are NOT available
      in this or future versions of getID3().
-     (thanks ahØartemis*dk)
-   » MD5 hashes are now available for all formats for both the entire
+     (thanks ahÃ˜artemis*dk)
+   Â» MD5 hashes are now available for all formats for both the entire
      file (['md5_file']) and the portion of the file containing only
      the audio/video data, stripped of all prepended/appended tags
      like ID3v2, ID3v1, APE, etc - ['md5_data']
-     (thanks ahØartemis*dk for alternate md5_file() function that
+     (thanks ahÃ˜artemis*dk for alternate md5_file() function that
      runs on UNIX system running PHP < 4.2.0)
      NOTE: Ogg files require the use of vorbiscomment to obtain the
      md5_data value. vorbiscomment must be downloaded from
@@ -1612,11 +1663,11 @@ Version History
      in the event that VorbisComments are larger than 1 page (4-8kB).
      NOTE: md5_data for Ogg will not work if PHP is running in Safe
      Mode
-   » There is now a wrapper class available, written by Allan Hansen,
+   Â» There is now a wrapper class available, written by Allan Hansen,
      which should simplify extracting most common basic information
      (such as format, bitrate, comments).
      New file: audioinfo.class.php
-   » OggWrite() in getid3.ogginfo.php has been replaced with a new
+   Â» OggWrite() in getid3.ogginfo.php has been replaced with a new
      version that uses vorbiscomment to write the comments, because
      of a reported bug that can corrupt OggVorbis files such they
      cannot be played.
@@ -1625,31 +1676,31 @@ Version History
      and placed in the getID3() directory.
      NOTE: Ogg comment writing will not work if PHP is running in
      Safe Mode
-   ¤ New root key ['tags'] is now always returned for all formats.
+   Â¤ New root key ['tags'] is now always returned for all formats.
      It is an array that may contain any of:
      * Native format tags: 'vqf', 'riff', 'vorbiscomment', 'asf',
        'nsv', 'real', 'midi', 'zip', 'quicktime'
      * Appended data tags:  'ape', 'lyrics3', 'id3v2', 'id3v1'
-   ¤ New root key ['audio'] is an array containing any or all of:
+   Â¤ New root key ['audio'] is an array containing any or all of:
        codec, channels, channelmode, bitrate, bits_per_sample,
        dataformat, bitrate_mode, sample_rate, encoder
        Note: This replaces several root keys, including:
          bitrate_audio, bits_per_sample, frequency, channels
-   ¤ New root key ['video'] is an array containing any or all of:
+   Â¤ New root key ['video'] is an array containing any or all of:
        bitrate_mode, bitrate, codec, resolution_x,  resolution_y,
        resolution_y, frame_rate, encoder
        Note: This replaces several root keys, including:
          bitrate_video, resolution_x, resolution_y, frame_rate
-   ¤ ['id3']['id3v1'] has moved to ['id3v1']
-   ¤ ['id3']['id3v2'] has moved to ['id3v2']
-   ¤ ['audiodataoffset'] and ['audiodataend'] have been renamed to
+   Â¤ ['id3']['id3v1'] has moved to ['id3v1']
+   Â¤ ['id3']['id3v2'] has moved to ['id3v2']
+   Â¤ ['audiodataoffset'] and ['audiodataend'] have been renamed to
      ['avdataoffset'] and ['avdataend'] respectively
-   ¤ GetAllMP3info() has been changed to GetAllFileInfo() with a
+   Â¤ GetAllMP3info() has been changed to GetAllFileInfo() with a
      different parameter list ($allowedFormats is no longer a
      parameter).  Check your code where you're calling
      GetAllMP3Info() - you will need to change both the function
      name and the parameter list if you pass more than 2 parameters
-   ¤ All formats now return ['audio']['dataformat'] and/or
+   Â¤ All formats now return ['audio']['dataformat'] and/or
      ['video']['dataformat'] where appropriate - this goes along with
      ['fileformat'] - ['fileformat'] will return the actual structure
      of the file, whereas ['dataformat'] will return the format of
@@ -1659,56 +1710,56 @@ Version History
      'ogg', but ['dataformat'] would be 'flac'.
      Note: this means that WAV and AVI files now return a
      ['fileformat'] of 'riff' rather than 'wav' or 'avi'.
-   ¤ ['filesize'] is no longer returned for files larger than 2GB
+   Â¤ ['filesize'] is no longer returned for files larger than 2GB
      because PHP does not support large file access. Attempting to
      parse a file larger than 2GB will result in a message stored in
      ['error'] and ['filesize'] not set.
-   ¤ APEtag, ID3v1, and ID3v2 are now supported on ALL multimedia
+   Â¤ APEtag, ID3v1, and ID3v2 are now supported on ALL multimedia
      files - even if illegal by format. Ogg will return warning if
-     ID3/APE tags are present.  (thanks ahØartemis*dk)
-   ¤ All files: non-critical errors are now returned in the root key
+     ID3/APE tags are present.  (thanks ahÃ˜artemis*dk)
+   Â¤ All files: non-critical errors are now returned in the root key
      ['warning'] rather than ['error'] (only critical errors that
      prevent getID3() from correctly parsing the file are returned in
-     ['error']  (thanks ahØartemis*dk)
-   ¤ Renamed all references to $MP3fileInfo to $ThisFileInfo
-   ¤ Joliet now supported for ISO-9660.
+     ['error']  (thanks ahÃ˜artemis*dk)
+   Â¤ Renamed all references to $MP3fileInfo to $ThisFileInfo
+   Â¤ Joliet now supported for ISO-9660.
      ['iso']['supplementary_volume_descriptor'] is now returned, if
      available, and ['iso']['files'] will contain ASCII equivalents
      of the Unicode directory structure & filenames stored.
-   ¤ Moved Monkey's Audio code from getid3.ape.php to seperate file.
+   Â¤ Moved Monkey's Audio code from getid3.ape.php to seperate file.
      New file: getid3.monkey.php
-   ¤ Added new keys for ISO-9660: ['name_ascii'] for directories,
+   Â¤ Added new keys for ISO-9660: ['name_ascii'] for directories,
      ['file_identifier_ascii'] for files
-   ¤ Added root key ['track'] for CD-audio files
-   ¤ Ogg/Vorbis-comment files now have comments returned inside
+   Â¤ Added root key ['track'] for CD-audio files
+   Â¤ Ogg/Vorbis-comment files now have comments returned inside
      ['ogg']['comments_common'] as an array of strings, rather than
      simple strings in ['ogg']
-   ¤ Quicktime files now have comments returned inside
+   Â¤ Quicktime files now have comments returned inside
      ['quicktime']['comments'] as an array of strings, rather than
      simple strings in ['quicktime']
-   ¤ ['mime_type'] is a new root key returned for all supported
-     formats (thanks ahØartemis*dk)
-   ¤ ['fileformat'] now returns 'mp1' instead of 'mp3' for MPEG-1
-     layer-I audio files (thanks ahØartemis*dk)
-   ¤ ['mpeg']['audio']['bitratemode'] now returns lowercase
-   ¤ MPEG-4 audio files which consist of MP3 data wrapped in a
+   Â¤ ['mime_type'] is a new root key returned for all supported
+     formats (thanks ahÃ˜artemis*dk)
+   Â¤ ['fileformat'] now returns 'mp1' instead of 'mp3' for MPEG-1
+     layer-I audio files (thanks ahÃ˜artemis*dk)
+   Â¤ ['mpeg']['audio']['bitratemode'] now returns lowercase
+   Â¤ MPEG-4 audio files which consist of MP3 data wrapped in a
      Quicktime fileformat will now return the usual data in
      ['mpeg']['audio']
-   ¤ Type-1 DV AVIs are now supported
-   ¤ DV AVIs will return 1 or 2 in ['RIFF']['video'][x]['dv_type']
-   ¤ Changed ['fileformat'] from 'mpg' to 'mpeg' for MPEG video files
-   ¤ ASF comments are now stored in ['asf']['comments'] instead of
+   Â¤ Type-1 DV AVIs are now supported
+   Â¤ DV AVIs will return 1 or 2 in ['RIFF']['video'][x]['dv_type']
+   Â¤ Changed ['fileformat'] from 'mpg' to 'mpeg' for MPEG video files
+   Â¤ ASF comments are now stored in ['asf']['comments'] instead of
      ['asf']
-   ¤ RealMedia chunk data is now returned inside ['real']['chunks']
+   Â¤ RealMedia chunk data is now returned inside ['real']['chunks']
      instead of ['real']
-   ¤ ['replay_gain'] now properly populated from APE tags
-   ¤ Added support for ASF_Old_ASF_Index_Object in ASF files
-     (thanks ahØartemis*dk)
-   ¤ AAC-ADTS files now return ['aac']['bitrate_distribution']
-   ¤ ParseVorbisComments() has been replaced with
+   Â¤ ['replay_gain'] now properly populated from APE tags
+   Â¤ Added support for ASF_Old_ASF_Index_Object in ASF files
+     (thanks ahÃ˜artemis*dk)
+   Â¤ AAC-ADTS files now return ['aac']['bitrate_distribution']
+   Â¤ ParseVorbisComments() has been replaced with
      ParseVorbisCommentsFilepointer() (with different parameters)
-   ¤ All references to any key ['frequency'] are now ['sample_rate']
-   ¤ Moved ID3v2 comments from ['id3v2'] into common root
+   Â¤ All references to any key ['frequency'] are now ['sample_rate']
+   Â¤ Moved ID3v2 comments from ['id3v2'] into common root
      ['comments'] structure, and now returns more values than before
    * Bugfix: ['iso']['files'] and ['zip']['files'] could potentially
      contain duplicate entries (in a numeric-indexed array) for files
@@ -1726,7 +1777,7 @@ Version History
    * Bugfix: Modified getid3.riff.php to return correct total
      bitrates for AVIs with multiple audio streams
    * Bugfix: GetFileFormat() was not creating array structure
-     correctly  (thanks ahØartemis*dk)
+     correctly  (thanks ahÃ˜artemis*dk)
    * Bugfix: LAME tag for MP3s can only specify up to 255kbps, so any
      files with actual CBR bitrate of >=256 were reported incorrectly
    * Bugfix: Lyrics3 synched lyrics were not being correctly returned
@@ -1735,7 +1786,7 @@ Version History
    * Bugfix: Incorrect pattern matching for ZIP files meant no zip
      files were being detected as such
    * Bugfix: AAC-ADIF was returning an incorrect number of channels
-     (too few) in some cases  (thanks ahØartemis*dk)
+     (too few) in some cases  (thanks ahÃ˜artemis*dk)
    * Bugfix: Vorbis comments were returning an incorrect value for
      ['dataoffset'] in some cases
    * Bugfix: MPEG video ['marker_bit'] and ['vbv_buffer_size'] were
@@ -1743,15 +1794,15 @@ Version History
    * Bugfix: ['playtime_string'] could potentially have a value of
      x minutes and 60 seconds (ie 3:60 instead of 4:00)
    Added support for FLAC cuesheets (FLAC 1.1.0+)
-     (thanks ahØartemis*dk)
-   Improved parsing speed in MP3, MP2 and AAC  (thanks ahØartemis*dk)
+     (thanks ahÃ˜artemis*dk)
+   Improved parsing speed in MP3, MP2 and AAC  (thanks ahÃ˜artemis*dk)
    Extra error-checking added to try and identify corrupt files for
-     most audio formats  (thanks ahØartemis*dk)
+     most audio formats  (thanks ahÃ˜artemis*dk)
    More accurate playtime calculation for RealMedia
-     (thanks ahØartemis*dk)
+     (thanks ahÃ˜artemis*dk)
    Changed all relevant files to use ['audiodataoffset'] and
      ['audiodataend'] rather than ['filesize'] where appropriate
-     (thanks ahØartemis*dk)
+     (thanks ahÃ˜artemis*dk)
    Added text encoding type 255 as a duplicate of UTF-16BE but with
      Big-Endian rather than Little-Endian byte order
    Added many RIFF-AVI audio types and fourcc video types to the
@@ -1782,19 +1833,19 @@ Version History
      manual conditional directory name replacement for special
      characters
    Added sample recursive scanning sample code to getid3.readme.txt
-     (thanks lipisinØmail*ru for the idea)
+     (thanks lipisinÃ˜mail*ru for the idea)
 
 
 1.5.7: [January-10-2003] James Heinrich
-   » Added support for ISO 9660 (CD-ROM image) format. Most-useful
+   Â» Added support for ISO 9660 (CD-ROM image) format. Most-useful
      data is directory structure returned under ['iso']['files']
      Note: Only ISO-9660 supported, not (yet) Joliet extension
-     (thanks nebula_djØsofthome*net for the idea)
+     (thanks nebula_djÃ˜softhome*net for the idea)
      New file: getid3.iso.php
-   ¤ ZIP files are now parsed by getID3() itself without relying on
+   Â¤ ZIP files are now parsed by getID3() itself without relying on
      built-in PHP functions and/or ZZipLib support.
      (thanks Vince for the idea)
-   ¤ ZIP files now return a simple directory listing with filename
+   Â¤ ZIP files now return a simple directory listing with filename
      and filesize info only under ['zip']['files'].
      Note: empty subdirectories will note appear in here, only files
      and non-empty subdirectories. Information for all entries,
@@ -1802,75 +1853,75 @@ Version History
      ['zip']['central_directory'] (or under ['zip']['entries'] if the
      Central Directory cannot be located (usually due to a trucated
      file).
-   ¤ RIFF-WAV files with MP3 data (or MP3s with RIFF headers, if you
+   Â¤ RIFF-WAV files with MP3 data (or MP3s with RIFF headers, if you
      want to think of it that way) now have the MPEG audio portion
      scanned and the usual data returned in ['mpeg']['audio'] if the
      RIFF audio codec has wFormatTag of "85" (identified by getID3()
      as "MPEG Layer 3")
-     (thanks ahØartemis*dk for the idea)
-   ¤ EXIF data (if present) is returned for JPEG files under
-     ['jpg']['exif']  (thanks nebula_djØsofthome*net)
-   ¤ ['filepath'] now returned for all files with the directory part
+     (thanks ahÃ˜artemis*dk for the idea)
+   Â¤ EXIF data (if present) is returned for JPEG files under
+     ['jpg']['exif']  (thanks nebula_djÃ˜softhome*net)
+   Â¤ ['filepath'] now returned for all files with the directory part
      of the full filename.
-   ¤ ['filenamepath'] is now returned for all files (equivalent to
+   Â¤ ['filenamepath'] is now returned for all files (equivalent to
      ['filepath'].'/'.['filename'])
    * Bugfix: ['id3']['id3v2'][<framename>]['dataoffset'] was wrong
    * Bugfix: MP3s tagged with iTunes have an invalid comment field
      frame name ('COM ' - should be 'COMM') but the data is valid
      otherwise; the frame is now renamed to 'COMM' and parsed
      normally (with the error noted in ['error'])
-     (thanks kheller2Ømac*com for the sample file)
+     (thanks kheller2Ã˜mac*com for the sample file)
    * Bugfix: Some ASF/WMA audio files were not being identified as
-     any format  (thanks ahØartemis*dk)
+     any format  (thanks ahÃ˜artemis*dk)
    * Bugfix: Warning now generated and ASCII format assumed for
      invalid text encoding values in ID3v2
    * Bugfix: Changed ZIP detection pattern from 'PK' to 'PK\x04\x03'
    * Bugfix: Ogg/FLAC files with large Vorbis comments were dying in
      an infinite loop with lots of error messages due to missing $fd
-     parameter on ParseVorbisComments()  (thanks ahØartemis*dk)
+     parameter on ParseVorbisComments()  (thanks ahÃ˜artemis*dk)
    * Bugfix: ['data'] and ['image_mime'] were being returned for all
      Ogg comments even if they were not images for versions of PHP
      that have image_type_to_mime_type() built in (ie PHP 4.3.0+)
 
 
 1.5.6: [December-31-2002] James Heinrich
-   » Added support for NSV (Nullsoft Streaming Video)
+   Â» Added support for NSV (Nullsoft Streaming Video)
      (www.nullsoft.com/nsv/)
-     (thanks demonØsoundplanet*com for the idea)
+     (thanks demonÃ˜soundplanet*com for the idea)
      New file: getid3.nsv.php
-   » Added support for CD-audio track files (track01.cda etc)
-   ¤ Added standard ['frame_rate'] root value when known (AVI, NSV,
+   Â» Added support for CD-audio track files (track01.cda etc)
+   Â¤ Added standard ['frame_rate'] root value when known (AVI, NSV,
      MPEG-video)
-   ¤ ASF files now report ['fileformat'] of:
+   Â¤ ASF files now report ['fileformat'] of:
      'wmv' when Windows Media Video codec v7/v8/v9 is used;
      'wma' when any 'Windows Media Audio' named audio codec is used
            and no video stream is present;
      'asf' in all other cases (audio-only, video-only, or both)
-   ¤ Removed support for ZIP functions (will be rewritten to not
+   Â¤ Removed support for ZIP functions (will be rewritten to not
      require ZZIPlib support in future versions)
-   ¤ Added function SafeStripSlashes() as a drop-in replacement for
+   Â¤ Added function SafeStripSlashes() as a drop-in replacement for
      stripslashes(), but that only strips slashes if magic_quotes_gpc
      is set
-   ¤ Removed support for remote file scanning (HTTP / FTP)
-   ¤ Added ['aac']['frames'] (number of AAC frames in file)
-   ¤ Added ['mpeg']['audio']['frame_count'] when a bitrate histogram
+   Â¤ Removed support for remote file scanning (HTTP / FTP)
+   Â¤ Added ['aac']['frames'] (number of AAC frames in file)
+   Â¤ Added ['mpeg']['audio']['frame_count'] when a bitrate histogram
      is created
-   ¤ Average bitrate for VBR MP3/MP2 is calculated from actual counts
+   Â¤ Average bitrate for VBR MP3/MP2 is calculated from actual counts
      of frames of various bitrates (rather than relying on the header
      values or filesize) when a bitrate histogram is created
-   ¤ RecursiveFrameScanning() split out into seperate function
+   Â¤ RecursiveFrameScanning() split out into seperate function
      (getid3.mp3.php)
-   ¤ Removed old function getMP3header() from getid3.mp3.php
-   ¤ Changed default MPEG_VALID_CHECK_FRAMES (number of mp3 frames
+   Â¤ Removed old function getMP3header() from getid3.mp3.php
+   Â¤ Changed default MPEG_VALID_CHECK_FRAMES (number of mp3 frames
      scanned to ensure a valid audio sequence has been located) from
      10 to 25. This means scanning will be slightly slower, but more
      reliable/accurate
    * Bugfix: ID3v2.2 - valid frame names not correctly detected
-     (thanks maeckerØweb*de for the sample file)
+     (thanks maeckerÃ˜web*de for the sample file)
    * Bugfix: ID3v2.2 - valid padding not correctly detected
-     (thanks maeckerØweb*de for the sample file)
+     (thanks maeckerÃ˜web*de for the sample file)
    * Bugfix: MIDI files with flat key signatures were not being
-     correctly reported (thanks alexleeisØshaw*ca for sample file)
+     correctly reported (thanks alexleeisÃ˜shaw*ca for sample file)
    * Bugfix: now returns message in ['error'] if file does not exist
    * Bugfix: ['RIFF']['video'][x]['codec'] wasn't always being
      correctly populated
@@ -1879,19 +1930,19 @@ Version History
      for multi-stream RealMedia
    * Bugfix: ChannelTypeID was incorrect in RVA2 ID3v2.4 frames
    * Bugfix: Fixed potential divide-by-zero error for corrupt FLAC
-     files  (thanks ahØartemis*dk)
+     files  (thanks ahÃ˜artemis*dk)
    * Bugfix: AAC-ADTS was not returning ['bitrate_mode'] unless
-     $ReturnExtendedInfo was TRUE  (thanks ahØartemis*dk)
+     $ReturnExtendedInfo was TRUE  (thanks ahÃ˜artemis*dk)
    * Bugfix: LAME-encoded CBR MP3s now properly identified as CBR
-     with correct bitrate  (thanks ahØartemis*dk)
+     with correct bitrate  (thanks ahÃ˜artemis*dk)
    * Bugfix: VBR MP2 (or headerless MP3) is now identified as VBR
      rather than CBR. Note: to obtain VBR bitrate for headerless
      files, the entire file is scanned and a histogram distribution
      of bitrates is created, and the average bitrate calculated from
-     that.  (thanks ahØartemis*dk for sample file)
+     that.  (thanks ahÃ˜artemis*dk for sample file)
    Added support for DSIZ chunks in VQF, and checks to make sure size
      of audio data matches DSIZ value, if present
-     (thanks ahØartemis*dk for sample file)
+     (thanks ahÃ˜artemis*dk for sample file)
    Rewrote GetAllMP3info() - removed some unneccesary code, changed
      format-detection routine from ParseAsThisFormat() to
      GetFileFormat() to allow for more flexible format parsing
@@ -1903,101 +1954,101 @@ Version History
      after the first frame has been successfully parsed (previously
      it would return FALSE if synch was lost at any time, meaning the
      file is most likely MP3, which was incorrect)
-     (thanks ahØartemis*dk for sample file)
+     (thanks ahÃ˜artemis*dk for sample file)
    Speed improvement code changes to getid3.mp3.php (up to 24% faster
-     in some cases)  (thanks ahØartemis*dk for the code)
+     in some cases)  (thanks ahÃ˜artemis*dk for the code)
    Changed all include_once() to require_once()
 
 
 1.5.5: [November-25-2002] James Heinrich
-   » Added support for La (Lossless Audio - www.lossless-audio.com)
-     (thanks ahØartemis*dk for the idea)
+   Â» Added support for La (Lossless Audio - www.lossless-audio.com)
+     (thanks ahÃ˜artemis*dk for the idea)
      New file: getid3.la.php
-   ¤ Moved lookup functions from getid3.lookup.php to the files where
+   Â¤ Moved lookup functions from getid3.lookup.php to the files where
      they are used.
      New file: getid3.id3.php
      New file: getid3.rgad.php
      Removed file: getid3.lookup.php
-   ¤ getID3v1Filepointer() returns FALSE if ID3v1 tag not found
-   ¤ Added new paramter "ReturnExtendedInfo" to the function
+   Â¤ getID3v1Filepointer() returns FALSE if ID3v1 tag not found
+   Â¤ Added new paramter "ReturnExtendedInfo" to the function
      getAACADTSheaderFilepointer() in getid3.aac.php which now
      defaults to FALSE - if TRUE then the data for every frame is
      returned (containing aac_frame_length, adts_buffer_fullness and
      num_raw_data_blocks, which aren't usually very useful). Speed
      improvement with FALSE is about 35%.
-   ¤ Now returns fopen() errors in ['error'], for example if a remote
+   Â¤ Now returns fopen() errors in ['error'], for example if a remote
      file is not accessible.
-   ¤ Changed default number of MP3 audio frames to scan to determine
+   Â¤ Changed default number of MP3 audio frames to scan to determine
      if a valid stream has been found from 5 to 10, now also defined
      as a constant at the top of getid3.mp3.php  This will result in
      slightly slower MP3 parsing, but greater reliability in
      detecting false/invalid/corrupted VBR headers.
-   ¤ fopen() errors now displayed in getid3.putid3.php
-     (thanks miguel.dieckmannØhamburg*de)
-   ¤ Added 4th parameter to decodeMPEGaudioHeader() $ScanAsCBR which
+   Â¤ fopen() errors now displayed in getid3.putid3.php
+     (thanks miguel.dieckmannÃ˜hamburg*de)
+   Â¤ Added 4th parameter to decodeMPEGaudioHeader() $ScanAsCBR which
      will force an MP3 audio frame sequence to be force-scanned in
      CBR mode. You should never need to call this directly, it's only
      used internally to scan for MP3 files that have an illegal VBR
-     header with CBR data. (thanks fletchØpobox*com)
+     header with CBR data. (thanks fletchÃ˜pobox*com)
    * Bugfix: ASF_Marker_Object in getid3.asf.php was always returning
      an error in non-existant "reserved_1" and failing
    * Bugfix: VBR bitrate calculations in getid3.mp3.php only occur if
      ['mpeg']['audio']['VBR_frames'] is defined.
-     (thanks fletchØpobox*com)
+     (thanks fletchÃ˜pobox*com)
    * Bugfix: getid3.putid3.php no longer deletes original MP3 if
-     ID3v2 tag writing fails (thanks miguel*dieckmannØhamburg*de)
+     ID3v2 tag writing fails (thanks miguel*dieckmannÃ˜hamburg*de)
    * Bugfix: incorrect order of if-statement error messages in
-     getid3.putid3.php (thanks miguel*dieckmannØhamburg*de)
+     getid3.putid3.php (thanks miguel*dieckmannÃ˜hamburg*de)
    getid3.asf.php now notes the error and continues parsing rather
      than failing when it encounters an error parsing a chunk
    Now actually scan 1000 frames for AAC ADTS as reported in the
-     v1.5.4 changelog, rather than 100. (thanks ahØartemis*dk)
+     v1.5.4 changelog, rather than 100. (thanks ahÃ˜artemis*dk)
    Improved scanning speed in getAACADTSheaderFilepointer() by ~30%
-     (thanks ahØartemis*dk for the fix)
+     (thanks ahÃ˜artemis*dk for the fix)
    Added FileSizeNiceDisplay() function to getid3.functions.php for
      formatting filesize output in kB, MB, GB, etc.
 
 
 1.5.4: [October-07-2002] James Heinrich
-   » Added support for Quicktime.
+   Â» Added support for Quicktime.
      New file: getid3.quicktime.php
-   » Added support for AAC files, both ADTS and ADIF header formats.
+   Â» Added support for AAC files, both ADTS and ADIF header formats.
      ADIF format is a pain because it's very similar to standard MP3
      header format, and it's hard to distinguish between the two. I
      have tried to make the detection accurate, but I have a limited
      number of AAC test files to play with so if you have an AAC file
      that gets detected as MP3/MP2 (or vice-versa), please send me
-     the details via email at infoØgetid3Øorg
+     the details via email at infoÃ˜getid3Ã˜org
      ADTS format is very slow to parse because to get the bitrate of
      VBR files the whole file has to be stepped through frame by
      frame (getID3() scans up to the first 1000 frames and assumes
      that to be close enough).
      Note: I would suggest commenting out support for AAC (see top of
      GetAllMP3info() function in getid3.php) unless you need it.
-     (thanks jfaulØgmx*de for the idea and sample Delphi source code)
+     (thanks jfaulÃ˜gmx*de for the idea and sample Delphi source code)
      New file: getid3.aac.php
-   » Added bitrate distribution analysis option for MP3 VBR files. A
+   Â» Added bitrate distribution analysis option for MP3 VBR files. A
      new boolean parameter for getOnlyMPEGaudioInfo() enabled this
      feature which steps through the MP3 file frame by frame and
      counts how many frames of each bitrate exist. This information
      is returned in ['mpeg']['audio']['bitrate_distribution']
      Caution: this feature is very inefficient for large files and
      takes a very long time and does lots of disk I/O. Use with care.
-   ¤ Changed layout of allowedFormats in GetAllMP3info() function in
+   Â¤ Changed layout of allowedFormats in GetAllMP3info() function in
      getid3.php to allow easy removal of support for any of the
      supported format. As stated above, I recommend commenting out
      AAC unless needed.
-   ¤ Added ['flac']['compressed_audio_bytes'],
+   Â¤ Added ['flac']['compressed_audio_bytes'],
      ['flac']['uncompressed_audio_bytes'], and
      ['flac']['compression_ratio']
-   ¤ Replaced FXPT2DOT30toFloat() function with FixedPoint2_30()
+   Â¤ Replaced FXPT2DOT30toFloat() function with FixedPoint2_30()
    * Bugfix: getid3.mpc.php was slightly miscalculating the number of
      samples, therefore also bitrate and playtime
-     (thanks ahØartemis*dk for the fix)
+     (thanks ahÃ˜artemis*dk for the fix)
    * Bugfix: MonkeyCompressionLevelNameLookup() didn't know about
-     'insane' compression (thanks ahØartemis*dk for the fix)
+     'insane' compression (thanks ahÃ˜artemis*dk for the fix)
    * Bugfix: MonkeySamplesPerFrame() was incorrect for MAC v3.95+
-     (thanks ahØartemis*dk for the fix)
+     (thanks ahÃ˜artemis*dk for the fix)
    * Bugfix: getid3.check.php wasn't processing the assumeFormat
      directive when (register_globals == off)
    * Bugfix: detecting of synch pattern for MP3 files with invalid
@@ -2005,47 +2056,47 @@ Version History
      incorrect bitrate/duration/etc info for such corrupt files.
    getid3.functions.php now includes a replacement utf8_decode()
      function for those PHP installations that are not configured
-     with the --with-xml option. (thanks stephaneØtekartists*com)
+     with the --with-xml option. (thanks stephaneÃ˜tekartists*com)
 
 
 1.5.3: [September-30-2002] James Heinrich
-   » Added support for VQF. (thanks mtØmansonthomas*com for the idea)
+   Â» Added support for VQF. (thanks mtÃ˜mansonthomas*com for the idea)
      New file: getid3.vqf.php
-   » Added support for FLAC. Comments, if present, are returned under
+   Â» Added support for FLAC. Comments, if present, are returned under
      ['ogg'] because they follow the Ogg Vorbis structure standard.
      New file: getid3.flac.php
-   ¤ OS/2-format bitmaps are now correctly interpreted. The format of
+   Â¤ OS/2-format bitmaps are now correctly interpreted. The format of
      the bitmap is now returned in ['bmp']['type_os'] and
      ['bmp']['type_version']. OS/2 bitmaps can be v1 or v2, Windows
      can be v1, v4 or v5
 
 
 1.5.2: [September-25-2002] James Heinrich
-   » Support for RealMedia (audio & video) added
+   Â» Support for RealMedia (audio & video) added
      Note: only tested on G2 and v5 audio and video files - if anyone
      has older and/or newer sample files, please test it and/or send
      me the sample files.
-     (thanks stephaneØtekartists*com for idea)
+     (thanks stephaneÃ˜tekartists*com for idea)
      New file: getid3.real.php
-   » Support for BMP added. Palette and pixel data can optionally be
+   Â» Support for BMP added. Palette and pixel data can optionally be
      extracted as well - this is slow and generally unneccesary, but
      the option is there if you need it. Also includes PlotBMP()
      which will take the extracted pixel data and output it as a true
      color PNG. This function requires GD v2.0+
      Note: Untested on 16-bit and 32-bit BMPs because I couldn't find
      any sample files - if you know of a program that can create such
-     files, please email infoØgetid3Øorg
+     files, please email infoÃ˜getid3Ã˜org
      Note: Support for RGB (uncompressed), RLE8 and RLE4 is included
      and tested. BITFIELDS support is also included for 16- & 32-bit
      formats, but it's untested, so if anybody has any test files
-     please send them to infoØgetid3Øorg
+     please send them to infoÃ˜getid3Ã˜org
      Note: Support currently only for Windows-format BMPs, and trying
      to parse an OS/2-format bitmap leads to unpredictable/invalid
      results.
      New file: getid3.bmp.php
-   » PNG now fully parsed, including all information chunks
+   Â» PNG now fully parsed, including all information chunks
      New file: getid3.png.php
-   ¤ Support for GIF/JPG/PNG moved to seperate files and expanded,
+   Â¤ Support for GIF/JPG/PNG moved to seperate files and expanded,
      including standard ['resolution_x'] and ['resolution_y'] as well
      as more thorough parsing of header information
      New file: getid3.gif.php
@@ -2053,21 +2104,21 @@ Version History
    table_var_dump() simplified and now outputs &#123;-style character
      entities for characters outside the normal alphanumeric range
    CleanOggCommentName() changed to a regular expression
-     (thanks chris-getid3Øbolt*cx for rewriting the function)
+     (thanks chris-getid3Ã˜bolt*cx for rewriting the function)
 
 
 1.5.1: [September-20-2002] James Heinrich
-   » Added support for MPEGplus/Musepack SV7. ['fileformat'] is 'SV7'
+   Â» Added support for MPEGplus/Musepack SV7. ['fileformat'] is 'SV7'
      for version 7 files (versions 4, 5 ,6 and 8 are not supported
      yet, but will be of ['fileformat'] SV4, SV5, SV6 and SV8) when
      they are supported (thanks Christian Fritz for the idea)
      New file: getid3.mpc.php
-   ¤ ['bitrate_audio'], ['bitrate_video'], ['bitrate_mode'],
+   Â¤ ['bitrate_audio'], ['bitrate_video'], ['bitrate_mode'],
      ['channels'], ['resolution_x'], and ['resolution_y'] keys added
      for all appropriate formats
-   ¤ Ogg files with a COVERART comment now save and display the
+   Â¤ Ogg files with a COVERART comment now save and display the
      attached image the same way as is done with ID3v2 APICs
-   ¤ ['ogg']['comments'][n]['data'] and
+   Â¤ ['ogg']['comments'][n]['data'] and
      ['ogg']['comments'][n]['dataoffset'] is now returned for all
      comments. ['ogg']['comments'][n]['data'] is only useful if
      the field is supposed to contain binary data. It is a
@@ -2075,26 +2126,26 @@ Version History
      ['ogg']['comments'][n]['dataoffset'] is the byte offset in the
      file at which the 'COMMENTNAME=value string' starts, not the
      start of just 'value'
-   ¤ ['ogg']['comments'][n]['image_mime'] is now returned if
+   Â¤ ['ogg']['comments'][n]['image_mime'] is now returned if
      ['ogg']['comments'][n]['data'] contains valid image data.
-   ¤ More than 3 Ogg pages may now be read in, if the comment data
+   Â¤ More than 3 Ogg pages may now be read in, if the comment data
      is longer than 1 page (usually about 4kB)
-   ¤ ['fileformat'] is now 'mp2' rather than 'mp3' if it's MPEG-1,
+   Â¤ ['fileformat'] is now 'mp2' rather than 'mp3' if it's MPEG-1,
      Layer-II audio
-   ¤ ASF bitrates now calculated even if stream_bitrate_properties
+   Â¤ ASF bitrates now calculated even if stream_bitrate_properties
      object not present
-   ¤ ['asf']['stream_properties_object'] is now a numeric-key array
+   Â¤ ['asf']['stream_properties_object'] is now a numeric-key array
      with one entry for each stream - the key being the stream number
-   ¤ ['replay_gain'] is returned for all audio formats that support
+   Â¤ ['replay_gain'] is returned for all audio formats that support
      it (MP3-LAME, ID3v2, Ogg) (thanks Christian Fritz for the idea)
-   ¤ ['mpeg']['audio']['LAME']['RGAD']['radio_replay_gain'] is now
+   Â¤ ['mpeg']['audio']['LAME']['RGAD']['radio_replay_gain'] is now
      ['mpeg']['audio']['LAME']['RGAD']['radio'] (same for audiophile)
-   ¤ ASF/WMA files now use WM/Track to get track number from if
-     WM/TrackNumber is not available (thanks stephaneØtekartists*com)
-   ¤ ASF/WMV files now returns ['year'] and ['asf']['year']
-   ¤ ASV/WMV files now use ['content_description']['description'] for
-     the ['comment'] field (thanks stephaneØtekartists*com)
-   ¤ ['track'] is now always returned as an integer
+   Â¤ ASF/WMA files now use WM/Track to get track number from if
+     WM/TrackNumber is not available (thanks stephaneÃ˜tekartists*com)
+   Â¤ ASF/WMV files now returns ['year'] and ['asf']['year']
+   Â¤ ASV/WMV files now use ['content_description']['description'] for
+     the ['comment'] field (thanks stephaneÃ˜tekartists*com)
+   Â¤ ['track'] is now always returned as an integer
    * Bugfix: Ogg comments that are larger than one data page (usually
      about 4kB) are now correctly parsed (thanks Christian Fritz)
    * Bugfix: Ogg comment data is now UTF8-decoded
@@ -2120,35 +2171,35 @@ Version History
 
 
 1.5.0: [September-18-2002] James Heinrich
-   » Ogg comment writing support added. getid3.write.php has been
+   Â» Ogg comment writing support added. getid3.write.php has been
      updated to allow for writing comment tags to both MP3 and Ogg.
-     Big thanks to Chris Bolt <chris-getid3Øbolt*cx> for writing the
+     Big thanks to Chris Bolt <chris-getid3Ã˜bolt*cx> for writing the
      OggWrite() function and offering it for inclusion in getID3()
      New file: getid3.ogginfo.php
-   » Support for Monkey's Audio and APE tag added.
+   Â» Support for Monkey's Audio and APE tag added.
      (thanks Christian Fritz for the idea)
      New file: getid3.ape.php
      ['fileformat'] now returns 'mac' for Monkey's Audio files, or
      'ape' for files with an APE tag (Monkey's Audio or other format)
-   » getid3.thumbnail.php has been removed from the distribution and
+   Â» getid3.thumbnail.php has been removed from the distribution and
      the table_var_dump() function now outputs APICs as seperate
      files in the same directory as the analyzed file. This should
      make the image-displaying more reliable as well as reduce
      complexity. The naming convention for the images is
      filename.ext.[byte offset of APIC data].[jpg|gif|png]
      If anybody still has any problems with corrupted images please
-     let me know at infoØgetid3Øorg
-   » Support for extended Xing/LAME tag
+     let me know at infoÃ˜getid3Ã˜org
+   Â» Support for extended Xing/LAME tag
      (see http://users.belgacom.net/gc247244/extra/tag.html)
      Data is returned in ['mpeg']['audio']['LAME']
-   ¤ ['ogg']['tracknumber'] has been renamed to ['ogg']['track'] and
+   Â¤ ['ogg']['tracknumber'] has been renamed to ['ogg']['track'] and
      ['track'] is now returned in the root of the array
-   ¤ ['ogg']['pageheader'][n]['flag'] has been renamed to
+   Â¤ ['ogg']['pageheader'][n]['flag'] has been renamed to
      ['ogg']['pageheader'][n]['flags'] and the unprocessed flag byte
      is available in ['ogg']['pageheader'][n]['flags_raw']
-   ¤ ['frequency'] is now returned for WAVE files in the root of the
-     array (thanks danielØelectroteque*org)
-   ¤ ASF files now return codec, bitrate, resolution, etc information
+   Â¤ ['frequency'] is now returned for WAVE files in the root of the
+     array (thanks danielÃ˜electroteque*org)
+   Â¤ ASF files now return codec, bitrate, resolution, etc information
      under ['asf']['video_media'] or ['asf']['audio_media']
    * Bugfix: RVA2 and EQU2 writing in getid3.putid3.php were
      incorrectly writing Volume Adjustment field
@@ -2163,8 +2214,8 @@ Version History
 
 
 1.4.3: [September-15-2002] James Heinrich
-   » Now parses ASF / WMV / WMA files
-   ¤ New file: getid3.asf.php
+   Â» Now parses ASF / WMV / WMA files
+   Â¤ New file: getid3.asf.php
    * Bugfix: RoughTranslateUnicodeToASCII() would return nothing
      if didn't find a terminator it was expecting
    Added FILETIMEtoUNIXtime() function (for converting 64-bit
@@ -2174,30 +2225,30 @@ Version History
 
 
 1.4.2: [September-12-2002] James Heinrich
-   » getID3() now requires PHP v4.1.0 or higher because it now is
+   Â» getID3() now requires PHP v4.1.0 or higher because it now is
      designed to work with register_globals = off and the new auto-
      globals ($_GET, $_SERVER, etc).
    * Bugfix: VBR MP3 files with Fraunhofer-style VBR header were not
      being correctly detected in most cases
-     (thanks dkushnerØoddcast*com and mikeØftl*com for sample files)
+     (thanks dkushnerÃ˜oddcast*com and mikeÃ˜ftl*com for sample files)
    * Bugfix: IsValidTextEncoding() was broken
    * Bugfix: Add stripslashes($EditorFilename) to getid3.write.php
      (writing was broken for files with ' or " in the filename)
-     (thanks mikeØftl*com and kthejoker)
+     (thanks mikeÃ˜ftl*com and kthejoker)
    * Bugfix: If there is garbage data between a valid VBR header
      frame and a sequence of valid MPEG-audio frames the VBR data is
-     no longer discarded. (thanks to mikeØftl*com for sample
+     no longer discarded. (thanks to mikeÃ˜ftl*com for sample
      Fraunhofer-style VBR file produced with MusicMatch v7.2)
-   ¤ Changed variable system to work with (register_globals = off)
-   ¤ Moved relevant code into seperate PlaytimeString() function
-   ¤ Added nl2br() to table_var_dump() for cleaner output
-   ¤ Now returns the following keys from Fraunhofer-VBR files:
+   Â¤ Changed variable system to work with (register_globals = off)
+   Â¤ Moved relevant code into seperate PlaytimeString() function
+   Â¤ Added nl2br() to table_var_dump() for cleaner output
+   Â¤ Now returns the following keys from Fraunhofer-VBR files:
      ['VBR_seek_offsets'], ['VBR_seek_offsets_stride'],
      ['VBR_offsets_relative'] and ['VBR_offsets_absolute']
-   ¤ Added ID3v1matchesID3v2() function and implemented in
+   Â¤ Added ID3v1matchesID3v2() function and implemented in
      getid3.check.php (thanks to "Guest" in the forums for the idea)
    Changed amount of data read in getid3.getimagesize.php from 10kB
-     to entire file. (thanks mikeØftl*com)
+     to entire file. (thanks mikeÃ˜ftl*com)
    Wrapped function_exists() checks around function definitions in
      getid3.functions.php
    Fixed a lot of E_WARNING and E_NOTICE situations, especially in
@@ -2208,18 +2259,18 @@ Version History
 
 1.4.1b5: [May-30-2002] James Heinrich
    * Bugfix: Unsynchronise() was broken, now fixed
-     (thanks mikeØftl*com)
+     (thanks mikeÃ˜ftl*com)
    * Bugfix: GenerateID3v2Tag() now correctly uses non-synchsafe
      integers for frame size descriptors in ID3v2.3 and ID3v2.2
-     (thanks mikeØftl*com)
-   ¤ Added ['artist'], ['title'], etc keys to root of returned
+     (thanks mikeÃ˜ftl*com)
+   Â¤ Added ['artist'], ['title'], etc keys to root of returned
      array to provide a common place to access any returned info
      from any file type. Currently gets info from ID3v1, ID3v2,
      Ogg, and RIFF/WAVE. Possible returned keys are:
      title, artist, album, year, genre, comment, track
-   ¤ Modified LookupGenre() function to search for either genre based
+   Â¤ Modified LookupGenre() function to search for either genre based
      on numeric ID, or now reverse lookup as well
-   ¤ Added ['artist'], ['title'], etc keys to ['RIFF'] information
+   Â¤ Added ['artist'], ['title'], etc keys to ['RIFF'] information
      if info tags are present
    Added functionality to attach a picture to the ID3v2 tag in
      getid3.write.php
@@ -2237,10 +2288,10 @@ Version History
      known format (for example if the header is corrupt), a more
      thorough scan is done based on the file extension
    Added 'Edit ID3' link from getid3.check.php to getid3.write.php for
-     MP3 files  (thanks maxØgutalin*com for the idea)
+     MP3 files  (thanks maxÃ˜gutalin*com for the idea)
    Added 'Delete file' link from getid3.check.php to getid3.write.php
      allowing you to permanently delete a file (be careful with this!!)
-     (thanks maxØgutalin*com for the idea)
+     (thanks maxÃ˜gutalin*com for the idea)
    Added some mouse-over titles for links in getid3.check.php
 
 
@@ -2254,16 +2305,16 @@ Version History
 
 
 1.4.1b3: [May-01-2002] James Heinrich
-   ¤ For Ogg files, now calculates the real average bitrate (returned
+   Â¤ For Ogg files, now calculates the real average bitrate (returned
      in ['ogg']['bitrate_average']) and so the playtime of the file is
      calculated on actual average bitrate, not nominal bitrate, so it
-     should be accurate now  (thanks to stephaneØtekartists*com for
+     should be accurate now  (thanks to stephaneÃ˜tekartists*com for
      telling me it was wrong)
    * Bugfix: ID3v2FrameIsAllowed() wasn't behaving properly if the
      writing functions were called for more than one file, because of
      the static array not being cleared between uses. This is an
      updated fix because the one in 1.4.1b2 didn't work :o)
-     (thanks soulcatcherØevilsoft*org and yoyo)
+     (thanks soulcatcherÃ˜evilsoft*org and yoyo)
    Added rawurlencode() to the filename parameter in table_var_dump()
      for images (wouldn't work with path/file names containing special
      characters (#, &, ", +)  (thanks Christian Fritz)
@@ -2275,7 +2326,7 @@ Version History
 
 
 1.4.1b2: [April-18-2002] James Heinrich
-   ¤ GetAllMP3Info()'s 2nd parameter has changed from boolean to string
+   Â¤ GetAllMP3Info()'s 2nd parameter has changed from boolean to string
      (now specifying the parse-this-file-as-this format, like 'mp3',
      but also can be FALSE to mean don't assume any format, auto-detect
      only), and a third parameter (array containing allowed formats)
@@ -2284,7 +2335,7 @@ Version History
      auto-detection of getID3() (ex: an MP3 wrapped in a RIFF/WAV
      header will be auto-detected as RIFF/WAV, but if forced to parse
      as MP3 will extract the original MP3 information)
-     (thanks reel_tazØusers*sourceforge*net)
+     (thanks reel_tazÃ˜users*sourceforge*net)
    * Bugfix: ID3v2FrameIsAllowed() wasn't behaving properly if the
      writing functions were called for more than one file, because of
      the static array not being cleared between uses (thanks yoyo)
@@ -2297,71 +2348,71 @@ Version History
    * Bugfix: RIFF/WAVE bitrate & playtime now better calculated
    * Bugfix: MP3 scanning for synch doesn't go beyond 64k now, to stop
      intensive scanning through large file that don't have a synch
-     (thanks soulcatcherØevilsoft*org for a weird sample file)
+     (thanks soulcatcherÃ˜evilsoft*org for a weird sample file)
    Improved performance when scanning for MP3 synch (about 600% faster
      if the synch is never found)
    ZIP files no longer return the contents of each compressed file, as
      that would very easily be more data than PHP could handle.
-     (thanks davidbullockØtech-center*com)
+     (thanks davidbullockÃ˜tech-center*com)
    getid3.check.php now displays entries in a more natural sort order:
      case insensitive, ignores most punctuation, treats accented chars
-     the same as their unaccent equivalent  (thanks mikeØftl*com)
+     the same as their unaccent equivalent  (thanks mikeÃ˜ftl*com)
    Added support for SmartSound-format RIFF files (which are regular
      RIFF/WAVE files with the first 4 chars changed from RIFF to SDSS)
    All instances of while(list() = each()) replaced with foreach()
 
 
 1.4.1b1: [April-11-2002] James Heinrich
-   » Parses MIDI files.
+   Â» Parses MIDI files.
      NOTE: very slow at parsing, much slower than any other file type
      NOTE: playtime is generally mostly accurate, but not always 100%
-   » Parses ZIP files (if ZZIPlib available, and only in PHP 4.0.7RC1
+   Â» Parses ZIP files (if ZZIPlib available, and only in PHP 4.0.7RC1
      and later (see http://www.php.net/manual/en/ref.zip.php)
      NOTE: currently untested as I'm unable to find php_zip.dll for
      PHP/Win32 - if someone has a copy of this file, please email me:
-     infoØgetid3Øorg
-   » Parses JPEG files (requires GD installed)
-   » Parses PNG files  (requires GD v1.6+ installed)
-   » Parses GIF files  (requires GD < v1.6 installed)
-   » For MP3s, once a valid synch is detected, the next 5 frames are
+     infoÃ˜getid3Ã˜org
+   Â» Parses JPEG files (requires GD installed)
+   Â» Parses PNG files  (requires GD v1.6+ installed)
+   Â» Parses GIF files  (requires GD < v1.6 installed)
+   Â» For MP3s, once a valid synch is detected, the next 5 frames are
      also scanned for valid synch signatures, to prevent false
      identification of synch. For corrupt MP3 files this will be a bit
      slower, but hopefully produce more reliable results.
-     (Thanks to mpdjØbtinternet*com for bringing this to my attention,
-     and xbhoffØpacbell*net for explaining what was happening)
+     (Thanks to mpdjÃ˜btinternet*com for bringing this to my attention,
+     and xbhoffÃ˜pacbell*net for explaining what was happening)
      (Thanks also to macik for helping me with MP3 frame lengths:
      http://66.96.216.160/cgi-bin/YaBB.pl
      ?board=c&action=display&num=1018474068)
-   » The actual image data is now displayed (for JPEG, PNG and GIF
+   Â» The actual image data is now displayed (for JPEG, PNG and GIF
      images only) rather than a binary text dump in getid3.check.php
      (specifically table_var_dump()) for APIC frames. Made possible
      by the inclusion of (a modified version of) GetURLImageSize() by
      Filipe Laborde-Basto (www.rezox.com). You can right-click, save-as
      to extract the image to a file.
      NOTE: The actual image data is still returned in ['data']
-   ¤ ['image_mime'], ['image_width'], ['image_height'], ['image_bytes']
+   Â¤ ['image_mime'], ['image_width'], ['image_height'], ['image_bytes']
      are now returned for APICs
-   ¤ split parsing functions out into seperate files: lyrics3, id3v1,
+   Â¤ split parsing functions out into seperate files: lyrics3, id3v1,
      id3v2, mp3, ogg, riff, mpeg, midi, zip
-   ¤ ['ogg']['bitrate_ave'] -> ['ogg']['bitrate_nominal'] (thanks to
-     stephaneØtekartists*com for pointing out that "nominal" bitrate
+   Â¤ ['ogg']['bitrate_ave'] -> ['ogg']['bitrate_nominal'] (thanks to
+     stephaneÃ˜tekartists*com for pointing out that "nominal" bitrate
      may actually differ significantly from the "average" bitrate)
      The real average bitrate seems to be only extractable by parsing
      the entire file and calculating the average bitrate. This is not
      yet an option, but hopefully in a future version of getID3()
-   ¤ ['filename'] now returned for all files
-   ¤ ['ogg']['date'] and ['ogg']['description'] now returned when
-     available  (thanks stephaneØtekartists*com)
-   ¤ ['mpeg']['audio']['crc'] now contains the CRC (if present)
-   ¤ ['bitrate'] is now returned as a double instead of an int
-   ¤ ['dataoffset'] is now returned for all ID3v2 frames
+   Â¤ ['filename'] now returned for all files
+   Â¤ ['ogg']['date'] and ['ogg']['description'] now returned when
+     available  (thanks stephaneÃ˜tekartists*com)
+   Â¤ ['mpeg']['audio']['crc'] now contains the CRC (if present)
+   Â¤ ['bitrate'] is now returned as a double instead of an int
+   Â¤ ['dataoffset'] is now returned for all ID3v2 frames
    * Bugfix: MP3 CRC presence ['mpeg']['audio']['protection'] was being
      reported as opposite of what it actually should be
    * Bugfix: MPEG videos weren't being detected (they were being
      parsed as MP3), and even if they were, there was a typo in
      getMPEGHeaderFilepointer()  (thanks Christian Fritz)
    * Bugfix: getid3.functions.php wasn't being included in
-     getid3.write.php  (thanks mikeØftl*com)
+     getid3.write.php  (thanks mikeÃ˜ftl*com)
    * Bugfix: Browse:___ directory name in getid3.check.php wasn't
      correct with directory names with ' and other strange characters
      (thanks Christian Fritz)
@@ -2369,7 +2420,7 @@ Version History
      after it encounters an invalid FrameID, and if the next frameID
      appears valid, it will just skip the current (invalid) frame and
      continue processing (it would previously abort at the first sign
-     of incorrect structure)   (thanks stephaneØtekartists*com)
+     of incorrect structure)   (thanks stephaneÃ˜tekartists*com)
    getid3.check.php now scans filetypes based on content, not filename
      extension, and shows the filetype in the displayed output. Files
      are only scanned as MP3 if ID3v2 or MPEG-audio signatures are at
@@ -2386,9 +2437,9 @@ Version History
 
 
 1.4.0b9: [April-05-2002] James Heinrich
-   » Ogg files now return bitrate and playtime (playtime calculated
+   Â» Ogg files now return bitrate and playtime (playtime calculated
      from nominal bitrate and filesize, so it's only approximately
-     accurate).  (thanks stephaneØtekartists*com for the idea)
+     accurate).  (thanks stephaneÃ˜tekartists*com for the idea)
    * Bugfix: ID3v1 tags were not properly being parsed - track, genre
      and comment fields were incorrect.  (thanks Christian Fritz)
    * Bugfix: getid3.check.php would not browse directories with single
@@ -2409,35 +2460,35 @@ Version History
    Changed default ID3v2 majorversion from 2.4 to 2.3 in
      getid3.write.php because Winamp (and probably many other
      ID3v2-aware tools) can only read up to ID3v2.3
-     (thanks mikeØftl*com)
+     (thanks mikeÃ˜ftl*com)
 
 
 1.4.0b8: [April-04-2002] James Heinrich
-   » Lyrics3 support added  (thanks Christian Fritz for the idea)
-   ¤ check.php renamed to getid3.check.php
-   ¤ write.php renamed to getid3.write.php
-   ¤ ['id3']['id3v2']['error'] (if present) now reported in ['error']
-   ¤ ['mpeg']['audio']['error'] (if present) now reported in ['error']
+   Â» Lyrics3 support added  (thanks Christian Fritz for the idea)
+   Â¤ check.php renamed to getid3.check.php
+   Â¤ write.php renamed to getid3.write.php
+   Â¤ ['id3']['id3v2']['error'] (if present) now reported in ['error']
+   Â¤ ['mpeg']['audio']['error'] (if present) now reported in ['error']
    * Bugfix: RoughTranslateUnicodeToASCII() was completely mangling
      UTF-16/UTF-16BE encoded text
    * Bugfix: The warning about MP3ext wasn't always showing up
-     (thanks davidbullockØtech-center*com)
+     (thanks davidbullockÃ˜tech-center*com)
    getID3v1Filepointer() cleaned up & shortened
    Moved the include_once() statements around so that a minimum of code
      is included
 
 
 1.4.0b7: [April-03-2002] James Heinrich
-   » RIFFs (specifically AVIs) are now more completely parsed,
+   Â» RIFFs (specifically AVIs) are now more completely parsed,
      almost everything in the returned ['RIFF'] array has been moved
      around and/or restructured. A lot of new data is in there too -
      codecs, frame size, etc.
-   ¤ Better recursive parsing of RIFFs (sub-arrays are now in the right
+   Â¤ Better recursive parsing of RIFFs (sub-arrays are now in the right
      place)
    * Bugfix: the isset() idea introduced in beta 5 was incorrectly
      implemented, such that ['asciidata'] and ['asciidescription'] were
      never returned - this had the side effect that ID3v2 comments were
-     not copied to ['id3']['id3v2']['comment']  (thanks mikeØftl*com)
+     not copied to ['id3']['id3v2']['comment']  (thanks mikeÃ˜ftl*com)
    * Bugfix: MPEG audio synch wasn't being detected, and therefore MPEG
      audio data not parsed, if no ID3v2 header present in an MP3
    ID3v1 track number only returned if greater than zero
@@ -2455,14 +2506,14 @@ Version History
      speed
    Added constant FREAD_BUFFER_SIZE for many fread() operations
    Added !== FALSE check to while(fread()) loops
-     (thanks davidbullockØtech-center*com)
+     (thanks davidbullockÃ˜tech-center*com)
    Added more entries to RIFFwFormatTagLookup()
      (still looking for a good complete list)
    Converted use of hexdec() in getid3.lookup.php to 0x1234 notation
 
 
 1.4.0b5: [March-28-2002] James Heinrich
-   ¤ Renamed decodeheader() to decodeMPEGaudioHeader()
+   Â¤ Renamed decodeheader() to decodeMPEGaudioHeader()
    * Bugfix: Fixed infinite loop problem for RIFF/WAV files with
      unknown chunks
    * Bugfix: WXXX frames were incorrectly writing from ['URL'] instead
@@ -2471,27 +2522,27 @@ Version History
      UTF-16/UTF-16BE
    Changed all quoted strings from " to ' to hopefully improve speed
      (although benchmarks have not yet shown any significant
-     improvement in speed)  (thanks davidbullockØtech-center*com)
+     improvement in speed)  (thanks davidbullockÃ˜tech-center*com)
    Improved code in check.php for dealing with symbolic links
-     (thanks davidbullockØtech-center*com)
-   Changed '<?' tags to '<?php'  (thanks davidbullockØtech-center*com)
+     (thanks davidbullockÃ˜tech-center*com)
+   Changed '<?' tags to '<?php'  (thanks davidbullockÃ˜tech-center*com)
    Added processing time indicator in check.php
      (ie 'directory scanned in 2.45 seconds')
    Replaced all instances of feof() to prevent infinite loop conditions
    Moved lookup portions of decodeMPEGaudioHeader() to
      getid3.lookup.php
    Replaced $arrayname[$index] with $arrayname["$index"] to avoid PHP
-     E_NOTICEs  (thanks davidbullockØtech-center*com)
+     E_NOTICEs  (thanks davidbullockÃ˜tech-center*com)
    Wrapped isset() around many if statements, to avoid PHP E_NOTICEs,
      hence improve speed (up to 30x speed improvement reported in some
      cases :)
 
 
 1.4.0b4: [March-26-2002] James Heinrich
-   ¤ RIFF/WAV file format now parsed, returned under ['riff']
-   ¤ Support for Relative Gain Adjustment in RIFF/WAV files
-   ¤ ['channels'] (1 or 2) now returned for MP3 and WAV files
-   ¤ ['bitrate'] now returned (in bits-per-second) at root level for
+   Â¤ RIFF/WAV file format now parsed, returned under ['riff']
+   Â¤ Support for Relative Gain Adjustment in RIFF/WAV files
+   Â¤ ['channels'] (1 or 2) now returned for MP3 and WAV files
+   Â¤ ['bitrate'] now returned (in bits-per-second) at root level for
      MP3 and WAV files
    Added support for RGAD (Relative Gain ADjustment) ID3v2 frames, both
      reading & writing
@@ -2507,69 +2558,69 @@ Version History
 
 
 1.4.0b3: [March-25-2002] James Heinrich
-   ¤ ['asciidata'] for WXXX frames now returns correct information, but
+   Â¤ ['asciidata'] for WXXX frames now returns correct information, but
      under ['asciidescription']  (thanks Christian Fritz)
-   ¤ Added ['framenamelong'] to all returned frame data arrays with
+   Â¤ Added ['framenamelong'] to all returned frame data arrays with
      text description of that frame (ie 'RVA2' would return 'Relative
      volume adjustment (2)')  (thanks Christian Fritz)
-   ¤ ['datalength'] is now ['indexeddatalength'] in ASPI frames (was
+   Â¤ ['datalength'] is now ['indexeddatalength'] in ASPI frames (was
      confliciting with the all-frames ['datalength'] as introduced in
      v1.4.0b1
-   ¤ ['datalength'] now returned as integer (rather than double) where
+   Â¤ ['datalength'] now returned as integer (rather than double) where
      possible
 
 
 1.4.0b2: [March-21-2002] James Heinrich
-   ¤ ['mpeg']['audio']['bitrate'] now returned as int rather than
+   Â¤ ['mpeg']['audio']['bitrate'] now returned as int rather than
      double for VBR files
    * Bugfix: MPEG audio information wasn't being parsed on files that
      had neither ID3v1 or ID3v2
    * Bugfix: COMM/WXXX frames weren't returning 'asciidata' in
      ID3v2.2, which also meant the ['id3']['id3v2']['comment'] field
-     wasn't being returned  (thanks stephaneØtekartists*com)
+     wasn't being returned  (thanks stephaneÃ˜tekartists*com)
    * Bugfix: file might not be found if filename actually contains
      escaped chars or %xx-formatted characters
-     (thanks reel_tazØusers*sourceforge*net)
+     (thanks reel_tazÃ˜users*sourceforge*net)
    Added support for running with Register Globals turned off
-     (thanks reel_tazØusers*sourceforge*net)
+     (thanks reel_tazÃ˜users*sourceforge*net)
    Added urlencode() where needed in check.php
-     (thanks reel_tazØusers*sourceforge*net)
+     (thanks reel_tazÃ˜users*sourceforge*net)
    Fixed IE buffering/display problem in progress counter in check.php
 
 
 1.4.0b1: [March-11-2002] James Heinrich
-   » ID3v2 writing support via WriteID3v2() in putid3.php
+   Â» ID3v2 writing support via WriteID3v2() in putid3.php
      RemoveID3v2() and RemoveID3v1() functions now available in
      putid3.php  All ID3v1 and ID3v2 writing functions have been moved
      to putid3.php and example file write.php has been added to the
      distribution
-   ¤ MPEG audio frame information (bitrate, frequency, etc) now
+   Â¤ MPEG audio frame information (bitrate, frequency, etc) now
      returned inside ['mpeg']['audio'] instead of just ['mpeg']
-   ¤ MPEG video information now parsed, returned in ['mpeg']['video']
+   Â¤ MPEG video information now parsed, returned in ['mpeg']['video']
      Note: audio portion of video system files is not yet being parsed
-   ¤ All flag bits are now returned as boolean rather than int or
+   Â¤ All flag bits are now returned as boolean rather than int or
      string
-   ¤ RVA2 data now returned as an array (multiple RVA2 tags are
+   Â¤ RVA2 data now returned as an array (multiple RVA2 tags are
      allowed)
-   ¤ RVA2/EQU2 description returned under ['description'] rather than
+   Â¤ RVA2/EQU2 description returned under ['description'] rather than
      ['identification']
-   ¤ RVAD/EQUA adjustments now returned as signed integers, rather than
+   Â¤ RVAD/EQUA adjustments now returned as signed integers, rather than
      absolute values which required you to check flag bytes
-   ¤ RVRB/REV data no longer returns under ['reverb'] array
-   ¤ WXXX/W???/LINK frames now return ['url'] instead of ['URL']
-   ¤ USER now properly returns both ['language'] and ['languagename']
-   ¤ OWNE now returns ['purchasedateunix'] as a UNIX timestamp
+   Â¤ RVRB/REV data no longer returns under ['reverb'] array
+   Â¤ WXXX/W???/LINK frames now return ['url'] instead of ['URL']
+   Â¤ USER now properly returns both ['language'] and ['languagename']
+   Â¤ OWNE now returns ['purchasedateunix'] as a UNIX timestamp
      (only if ['purchasedate'] is a valid date)
-   ¤ ['id3']['id3v2']['padding'] now returned with information on padding
-   ¤ ['headerlength'] now includes the initial 6 or 10 bytes of the
+   Â¤ ['id3']['id3v2']['padding'] now returned with information on padding
+   Â¤ ['headerlength'] now includes the initial 6 or 10 bytes of the
      ID3v2 header
-   ¤ ['artist'], ['title'], ['album'], ['tracknumber'], ['genre'] now
+   Â¤ ['artist'], ['title'], ['album'], ['tracknumber'], ['genre'] now
      returned for easier access for Ogg files
-   ¤ added ['datalength'] to all ID3v2 frames: length of frame data,
+   Â¤ added ['datalength'] to all ID3v2 frames: length of frame data,
      not including frame header
-   ¤ ['fileformat'] now returns 'id3' if there are ID3v1 or ID3v2 tags
+   Â¤ ['fileformat'] now returns 'id3' if there are ID3v1 or ID3v2 tags
      but no audio data
-   ¤ ['fileformat'] now returns 'mpg' if it's an MPEG system (video +
+   Â¤ ['fileformat'] now returns 'mpg' if it's an MPEG system (video +
      audio) file
    * Bugfix: RVAD was being parsed incorrectly
    * Bugfix: ['currency'] and ['purchasedate'] now correctly returned
@@ -2581,12 +2632,12 @@ Version History
    * Bugfix: ['imagetype'] now properly returned for 'PIC' frames in
      ID3v2.2
    * Bugfix: Genre not being written if not set in WriteID3v1()
-     (thanks reel_tazØusers*sourceforge*net)
+     (thanks reel_tazÃ˜users*sourceforge*net)
    * Bugfix: Changed write mode to 'r+b' from 'a+' because ID3v1 tags
      were being appended instead of overwritten if they already existed
-     (thanks reel_tazØusers*sourceforge*net)
+     (thanks reel_tazÃ˜users*sourceforge*net)
    * Bugfix: open would fail on filenames containing quotes
-     (thanks javierØcrackdealer*com)
+     (thanks javierÃ˜crackdealer*com)
    * Bugfix: various values were incorrectly returned (unneeded ord())
      in these frames: COMR, USER, ENCR, GRID, PRIV, SIGN
    * Bugfix: ASPI ['bitsperpoint'] was not correctly returned
@@ -2598,23 +2649,23 @@ Version History
    Added sample directory browser to check.php
    Seperated out MPEGaudio-parsing functionality into
      getOnlyMPEGaudioInfo() which may be called directly if you don't
-     need any ID3 parsing  (thanks djpretzelØcox*rr*com for idea)
+     need any ID3 parsing  (thanks djpretzelÃ˜cox*rr*com for idea)
    Reduced use of fread() for increased performance in
      getID3v1Filepointer()
    Added clearstatcache() before checking filesize - size after writing
      tag now correct
    Added hack for mp3Rage (www.chaoticsoftware.com) that puts
      ID3v2.3-formatted MIME type instead of 3-char ID3v2.2-format image
-     type  (thanks xbhoffØpacbell*net for test file)
+     type  (thanks xbhoffÃ˜pacbell*net for test file)
 
 
 1.3.2: [February-15-2002] James Heinrich
-   ¤ UFID/UFI, USLT/ULT, COMM/COM, APIC/PIC, GEOB/GEO, CRM, RVA2, EQU2,
+   Â¤ UFID/UFI, USLT/ULT, COMM/COM, APIC/PIC, GEOB/GEO, CRM, RVA2, EQU2,
      POPM/POP, AENC/CRA, ENCR and GRID frame data now returned under
      numeric array index rather than by ownerID
-   ¤ RVA2 frame data is now returned keyed by $channeltypeid instead of
+   Â¤ RVA2 frame data is now returned keyed by $channeltypeid instead of
      $frame_idstring
-   ¤ WXXX/WXX frame description now returned under ['description']
+   Â¤ WXXX/WXX frame description now returned under ['description']
      instead of ['data']
    Trailing null bytes now trimmed from frame (W??? & T???) text data
      (it shouldn't be there to begin with, but a sample file encoded by
@@ -2629,19 +2680,19 @@ Version History
      2-element array
    * Bugfix: USLT wasn't being correctly parsed
    Improved RoughTranslateUnicodeToASCII()
-     (thanks reel_tazØusers*sourceforge*net for Unicode test file)
+     (thanks reel_tazÃ˜users*sourceforge*net for Unicode test file)
 
 
 1.3.0: [February-13-2002] James Heinrich
-   » ID3v1 writing support via WriteID3v1()
-   ¤ MPEG audio frame information (bitrate, frequency, etc) now
+   Â» ID3v1 writing support via WriteID3v1()
+   Â¤ MPEG audio frame information (bitrate, frequency, etc) now
      returned inside ['mpeg']
-   ¤ ['mpeg']['raw'] returns the integer values of the bits for MPEG
+   Â¤ ['mpeg']['raw'] returns the integer values of the bits for MPEG
      audio information as returned in ['mpeg'] by decodeheader()
-     (thanks reel_tazØusers*sourceforge*net)
-   ¤ 'protection', 'padding', 'private', 'copyright' and 'original' now
+     (thanks reel_tazÃ˜users*sourceforge*net)
+   Â¤ 'protection', 'padding', 'private', 'copyright' and 'original' now
      return as boolean
-   ¤ 'bitrate' and 'frequency' now return as int (except in special
+   Â¤ 'bitrate' and 'frequency' now return as int (except in special
      case of 'free')
    Language name as well as code retured where appropriate
      (ie 'English' and 'eng')
@@ -2668,15 +2719,15 @@ Version History
 
 
 1.2.4: [January-26-2002] James Heinrich
-   » Basic support for reading Ogg-Vorbis comment tags
+   Â» Basic support for reading Ogg-Vorbis comment tags
 
 
 1.2.3: [January-24-2002] James Heinrich
-   » ID3v2.2.x 3-char FrameIDs are now fully parsed
+   Â» ID3v2.2.x 3-char FrameIDs are now fully parsed
      Note: While I've included support for 22 FrameIDs as defined in
      the specs, I don't have test files for all of them. If anyone
      knows of programs that generate any of the untested tags, please
-     email infoØgetid3Øorg ! Here's what's tested and not:
+     email infoÃ˜getid3Ã˜org ! Here's what's tested and not:
        Tested: T??, COM
      Untested: UFI, TXX, W??, WXX, IPL, MCI, ETC, MLL, STC, ULT, SLT,
                RVA, EQU, REV, PIC, GEO, CNT, POP, BUF, CRM, CRA, LNK
@@ -2686,9 +2737,9 @@ Version History
 
 
 1.2.2: [January-18-2002] James Heinrich
-   ¤ Parses ID3v2 genres into ['id3']['id3v2']['genreid'] and
+   Â¤ Parses ID3v2 genres into ['id3']['id3v2']['genreid'] and
      ['id3']['id3v2']['genrelist'] where appropriate
-     (thanks stephaneØtekartists*com for the idea)
+     (thanks stephaneÃ˜tekartists*com for the idea)
    Added ID3v2 genre abbreviations 'RX' (remix) and 'CR' (cover)
 
 
@@ -2696,47 +2747,47 @@ Version History
    * Bugfix: 'mp3' was being returned in ['format'], but 'zip' was
      being returned in ['fileformat'], both are now returned in
      ['fileformat']
-   ¤ Splits ['id3']['id3v2']['track'] in the format '5/12' into
+   Â¤ Splits ['id3']['id3v2']['track'] in the format '5/12' into
      ['track'] = '5' and ['totaltracks'] = '12'
-   ¤ Enabled ['id3']['id3v2']['title'] etc for ID3v2.2.x
-     (3-char frame names)  (thanks stephaneØtekartists*com)
-   ¤ Changed v1.?? version number format to v1.?.?
+   Â¤ Enabled ['id3']['id3v2']['title'] etc for ID3v2.2.x
+     (3-char frame names)  (thanks stephaneÃ˜tekartists*com)
+   Â¤ Changed v1.?? version number format to v1.?.?
    Scans through the file until it finds the MPEG synch (start of audio
      frame) - some files encoded by LAME 3.91 had undocumented padding
      after the ID3v2 header; getMP3headerFilepointer() now scans until
-     it finds synch (or EOF)  (thanks adamØtrekjapan*com)
+     it finds synch (or EOF)  (thanks adamÃ˜trekjapan*com)
    Improved Unicode conversion in RoughTranslateUnicodeToASCII()
 
 
 1.20:  [January-15-2002] James Heinrich
-   » Support for variable-bitrate (VBR) files, both Xing and Fraunhofer
+   Â» Support for variable-bitrate (VBR) files, both Xing and Fraunhofer
      headers
-   » All 4-character FrameIDs are now fully parsed according to the
+   Â» All 4-character FrameIDs are now fully parsed according to the
      specs at http://www.id3.org/id3v2.4.0-frames.txt
-     ¤ This means that most no longer return ['flags'] and ['data']
+     Â¤ This means that most no longer return ['flags'] and ['data']
      Note: While I've included support for 30 FrameIDs as defined in
      the specs, I don't have test files for all of them. If anyone
      knows of programs that generate any of the untested tags, please
-     email infoØgetid3Øorg ! Here's what's tested and not:
+     email infoÃ˜getid3Ã˜org ! Here's what's tested and not:
        Tested: UFID, T???, WXXX, USLT, SYLT, COMM, APIC, GEOB
      Untested: TXXX, W???, MCDI, ETCO, MLLT, SYTC, RVA2, EQU2, RVRB,
                PCNT, POPM, RBUF, AENC, USER, OWNE, COMR, ENCR, GRID,
                PRIV, SIGN, SEEK, ASPI
-   ¤ Added 'title', 'artist', etc names to ID3v2 data (easier to access
+   Â¤ Added 'title', 'artist', etc names to ID3v2 data (easier to access
      than the 4-character FrameIDs of the ID3v2 standard)
-     (thanks jaksonØgmx.net)
+     (thanks jaksonÃ˜gmx.net)
    * Bugfix: added fclose() at end of GetAllMP3Info()
-     (thanks stephaneØtekartists*com)
+     (thanks stephaneÃ˜tekartists*com)
    * Bugfix: ID3v1 wasn't being parsed if ID3v2 wasn't present
-     (thanks jaksonØgmx.net)
+     (thanks jaksonÃ˜gmx.net)
    * Bugfix: several flags were being parsed incorrectly (the structure
      had changed from ID3v2.3 to ID3v2.4) - v2.3 flags were being
      incorrectly parsed
    Much more compact implementation of decodeheader()
-     (thanks jaksonØgmx.net for the idea)
-   ID3v1 genres 126 through 147  (thanks jaksonØgmx.net)
+     (thanks jaksonÃ˜gmx.net for the idea)
+   ID3v1 genres 126 through 147  (thanks jaksonÃ˜gmx.net)
    New table_var_dump() function in check.php
-     (based partially on idea by jaksonØgmx.net)
+     (based partially on idea by jaksonÃ˜gmx.net)
    Seperated ID3v1 retrieval into seperate function
 
 
@@ -2751,7 +2802,7 @@ Version History
    Changed calling procedure to recommend using
      GetAllMP3info($filename) from getmp3header.php
    Now includes check.php - example file
-   ¤ Checks to see if file is in ZIP or MP3 format
+   Â¤ Checks to see if file is in ZIP or MP3 format
      (returned in ['format'])
      [Ed. Note: ['fileformat'] as of v1.2.1]
 
@@ -2759,7 +2810,7 @@ Version History
 1.06:  [November-05-2001] James Heinrich
    * Bugfix: ID3v2.2.x frames weren't being parsed since they use
      6-byte rather than 10-byte headers as v2.3+ does
-     (thanks spunkØmac*com for pointing that out)
+     (thanks spunkÃ˜mac*com for pointing that out)
 
 
 1.05:  [September-06-2001] James Heinrich
@@ -2768,7 +2819,7 @@ Version History
 
 1.04:  [July-16-2001] James Heinrich
    * Bugfix: typo in Extended Header section (strpad() should be
-     str_pad()) (thanks jurroonØyahoo*com)
+     str_pad()) (thanks jurroonÃ˜yahoo*com)
 
 
 1.03:  [May-07-2001] James Heinrich
@@ -2777,15 +2828,15 @@ Version History
 
 
 1.02:  [May-05-2001] James Heinrich
-   ¤ Added ['getID3version']
+   Â¤ Added ['getID3version']
 
 
 1.01:  [May-04-2001] James Heinrich
-   » Added support for frame-level de-unsynchronisation (as per
+   Â» Added support for frame-level de-unsynchronisation (as per
      ID3v2.4.0 specs) in addition to ID3v2.3.x tag-level
      de-unsynchronisation
 
 
 1.00:  [May-04-2001] James Heinrich
-   » Initial public release
+   Â» Initial public release
 

--- a/3rdparty/getID3/composer.json
+++ b/3rdparty/getID3/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "james-heinrich/getid3",
+    "description": "PHP script that extracts useful information from popular multimedia file formats",
+    "homepage": "http://www.getid3.org/",
+    "keywords": ["php","tags","codecs"],
+    "type": "library",
+    "license": "GPL",
+    "require":
+    {
+        "php": ">=5.3.0"
+    },
+    "autoload": {
+        "classmap": ["getid3/getid3.php"]
+    }
+}

--- a/3rdparty/getID3/getid3/extension.cache.dbm.php
+++ b/3rdparty/getID3/getid3/extension.cache.dbm.php
@@ -74,7 +74,7 @@ class getID3_cached_dbm extends getID3
 {
 
 	// public: constructor - see top of this file for cache type and cache_options
-	public function getID3_cached_dbm($cache_type, $dbm_filename, $lock_filename) {
+	public function __construct($cache_type, $dbm_filename, $lock_filename) {
 
 		// Check for dba extension
 		if (!extension_loaded('dba')) {

--- a/3rdparty/getID3/getid3/extension.cache.mysql.php
+++ b/3rdparty/getID3/getid3/extension.cache.mysql.php
@@ -80,7 +80,7 @@ class getID3_cached_mysql extends getID3
 
 
 	// public: constructor - see top of this file for cache type and cache_options
-	public function getID3_cached_mysql($host, $database, $username, $password, $table='getid3_cache') {
+	public function __construct($host, $database, $username, $password, $table='getid3_cache') {
 
 		// Check for mysql support
 		if (!function_exists('mysql_pconnect')) {
@@ -134,7 +134,7 @@ class getID3_cached_mysql extends getID3
 
 
 	// public: analyze file
-	public function analyze($filename) {
+	public function analyze($filename, $filesize=null, $original_filename='') {
 
 		if (file_exists($filename)) {
 
@@ -157,7 +157,7 @@ class getID3_cached_mysql extends getID3
 		}
 
 		// Miss
-		$analysis = parent::analyze($filename);
+		$analysis = parent::analyze($filename, $filesize, $original_filename);
 
 		// Save result
 		if (file_exists($filename)) {
@@ -178,11 +178,11 @@ class getID3_cached_mysql extends getID3
 	private function create_table($drop=false) {
 
 		$SQLquery  = 'CREATE TABLE IF NOT EXISTS `'.mysql_real_escape_string($this->table).'` (';
-		$SQLquery .=   '`filename` VARCHAR(255) NOT NULL DEFAULT \'\'';
+		$SQLquery .=   '`filename` VARCHAR(500) NOT NULL DEFAULT \'\'';
 		$SQLquery .= ', `filesize` INT(11) NOT NULL DEFAULT \'0\'';
 		$SQLquery .= ', `filetime` INT(11) NOT NULL DEFAULT \'0\'';
 		$SQLquery .= ', `analyzetime` INT(11) NOT NULL DEFAULT \'0\'';
-		$SQLquery .= ', `value` TEXT NOT NULL';
+		$SQLquery .= ', `value` LONGTEXT NOT NULL';
 		$SQLquery .= ', PRIMARY KEY (`filename`, `filesize`, `filetime`)) ENGINE=MyISAM';
 		$this->cursor = mysql_query($SQLquery, $this->connection);
 		echo mysql_error($this->connection);

--- a/3rdparty/getID3/getid3/extension.cache.sqlite3.php
+++ b/3rdparty/getID3/getid3/extension.cache.sqlite3.php
@@ -49,20 +49,20 @@
 *
 *   sqlite3             table='getid3_cache', hide=false        (PHP5)
 *
-
-***  database file will be stored in the same directory as this script,
-***  webserver must have write access to that directory!
-***  set $hide to TRUE to prefix db file with .ht to pervent access from web client
-***  this is a default setting in the Apache configuration:
-
-# The following lines prevent .htaccess and .htpasswd files from being viewed by Web clients.
-
-<Files ~ "^\.ht">
-    Order allow,deny
-    Deny from all
-    Satisfy all
-</Files>
-
+*
+* ***  database file will be stored in the same directory as this script,
+* ***  webserver must have write access to that directory!
+* ***  set $hide to TRUE to prefix db file with .ht to pervent access from web client
+* ***  this is a default setting in the Apache configuration:
+*
+* The following lines prevent .htaccess and .htpasswd files from being viewed by Web clients.
+*
+* <Files ~ "^\.ht">
+*     Order allow,deny
+*     Deny from all
+*     Satisfy all
+* </Files>
+*
 ********************************************************************************
 *
 *   -------------------------------------------------------------------
@@ -159,13 +159,13 @@ class getID3_cached_sqlite3 extends getID3 {
 	* @param type $filename
 	* @return boolean
 	*/
-	public function analyze($filename) {
+	public function analyze($filename, $filesize=null, $original_filename='') {
 		if (!file_exists($filename)) {
 			return false;
 		}
 		// items to track for caching
 		$filetime = filemtime($filename);
-		$filesize = filesize($filename);
+		$filesize_real = filesize($filename);
 		// this will be saved for a quick directory lookup of analized files
 		// ... why do 50 seperate sql quries when you can do 1 for the same result
 		$dirname  = dirname($filename);
@@ -173,25 +173,25 @@ class getID3_cached_sqlite3 extends getID3 {
 		$db = $this->db;
 		$sql = $this->get_id3_data;
 		$stmt = $db->prepare($sql);
-		$stmt->bindValue(':filename', $filename, SQLITE3_TEXT);
-		$stmt->bindValue(':filesize', $filesize, SQLITE3_INTEGER);
-		$stmt->bindValue(':filetime', $filetime, SQLITE3_INTEGER);
+		$stmt->bindValue(':filename', $filename,      SQLITE3_TEXT);
+		$stmt->bindValue(':filesize', $filesize_real, SQLITE3_INTEGER);
+		$stmt->bindValue(':filetime', $filetime,      SQLITE3_INTEGER);
 		$res = $stmt->execute();
 		list($result) = $res->fetchArray();
 		if (count($result) > 0 ) {
 			return unserialize(base64_decode($result));
 		}
 		// if it hasn't been analyzed before, then do it now
-		$analysis = parent::analyze($filename);
+		$analysis = parent::analyze($filename, $filesize, $original_filename);
 		// Save result
 		$sql = $this->cache_file;
 		$stmt = $db->prepare($sql);
-		$stmt->bindValue(':filename', $filename, SQLITE3_TEXT);
-		$stmt->bindValue(':dirname', $dirname, SQLITE3_TEXT);
-		$stmt->bindValue(':filesize', $filesize, SQLITE3_INTEGER);
-		$stmt->bindValue(':filetime', $filetime, SQLITE3_INTEGER);
-		$stmt->bindValue(':atime', time(), SQLITE3_INTEGER);
-		$stmt->bindValue(':val', base64_encode(serialize($analysis)), SQLITE3_TEXT);
+		$stmt->bindValue(':filename', $filename,                           SQLITE3_TEXT);
+		$stmt->bindValue(':dirname',  $dirname,                            SQLITE3_TEXT);
+		$stmt->bindValue(':filesize', $filesize_real,                      SQLITE3_INTEGER);
+		$stmt->bindValue(':filetime', $filetime,                           SQLITE3_INTEGER);
+		$stmt->bindValue(':atime',    time(),                              SQLITE3_INTEGER);
+		$stmt->bindValue(':val',      base64_encode(serialize($analysis)), SQLITE3_TEXT);
 		$res = $stmt->execute();
 		return $analysis;
 	}
@@ -253,7 +253,8 @@ class getID3_cached_sqlite3 extends getID3 {
 				return "INSERT INTO $this->table (filename, dirname, filesize, filetime, analyzetime, val) VALUES (:filename, :dirname, :filesize, :filetime, :atime, :val)";
 				break;
 			case 'make_table':
-				return "CREATE TABLE IF NOT EXISTS $this->table (filename VARCHAR(255) NOT NULL DEFAULT '', dirname VARCHAR(255) NOT NULL DEFAULT '', filesize INT(11) NOT NULL DEFAULT '0', filetime INT(11) NOT NULL DEFAULT '0', analyzetime INT(11) NOT NULL DEFAULT '0', val text not null, PRIMARY KEY (filename, filesize, filetime))";
+				//return "CREATE TABLE IF NOT EXISTS $this->table (filename VARCHAR(255) NOT NULL DEFAULT '', dirname VARCHAR(255) NOT NULL DEFAULT '', filesize INT(11) NOT NULL DEFAULT '0', filetime INT(11) NOT NULL DEFAULT '0', analyzetime INT(11) NOT NULL DEFAULT '0', val text not null, PRIMARY KEY (filename, filesize, filetime))";
+				return "CREATE TABLE IF NOT EXISTS $this->table (filename VARCHAR(255) DEFAULT '', dirname VARCHAR(255) DEFAULT '', filesize INT(11) DEFAULT '0', filetime INT(11) DEFAULT '0', analyzetime INT(11) DEFAULT '0', val text, PRIMARY KEY (filename, filesize, filetime))";
 				break;
 			case 'get_cached_dir':
 				return "SELECT val FROM $this->table WHERE dirname = :dirname";

--- a/3rdparty/getID3/getid3/getid3.lib.php
+++ b/3rdparty/getID3/getid3/getid3.lib.php
@@ -414,6 +414,20 @@ class getid3_lib
 		return $newarray;
 	}
 
+	public static function flipped_array_merge_noclobber($array1, $array2) {
+		if (!is_array($array1) || !is_array($array2)) {
+			return false;
+		}
+		# naturally, this only works non-recursively
+		$newarray = array_flip($array1);
+		foreach (array_flip($array2) as $key => $val) {
+			if (!isset($newarray[$key])) {
+				$newarray[$key] = count($newarray);
+			}
+		}
+		return array_flip($newarray);
+	}
+
 
 	public static function ksort_recursive(&$theArray) {
 		ksort($theArray);
@@ -519,15 +533,14 @@ class getid3_lib
 	}
 
 	public static function XML2array($XMLstring) {
-		if (function_exists('simplexml_load_string')) {
-			if (function_exists('get_object_vars')) {
-				if (function_exists('libxml_disable_entity_loader')) { // (PHP 5 >= 5.2.11)
-					// http://websec.io/2012/08/27/Preventing-XEE-in-PHP.html
-					libxml_disable_entity_loader(true);
-				}
-				$XMLobject = simplexml_load_string($XMLstring);
-				return self::SimpleXMLelement2array($XMLobject);
-			}
+		if (function_exists('simplexml_load_string') && function_exists('libxml_disable_entity_loader')) {
+			// http://websec.io/2012/08/27/Preventing-XEE-in-PHP.html
+			// https://core.trac.wordpress.org/changeset/29378
+			$loader = libxml_disable_entity_loader(true);
+			$XMLobject = simplexml_load_string($XMLstring, 'SimpleXMLElement', LIBXML_NOENT);
+			$return = self::SimpleXMLelement2array($XMLobject);
+			libxml_disable_entity_loader($loader);
+			return $return;
 		}
 		return false;
 	}
@@ -1154,11 +1167,19 @@ class getid3_lib
 	public static function GetDataImageSize($imgData, &$imageinfo=array()) {
 		static $tempdir = '';
 		if (empty($tempdir)) {
+			if (function_exists('sys_get_temp_dir')) {
+				$tempdir = sys_get_temp_dir(); // https://github.com/JamesHeinrich/getID3/issues/52
+			}
+
 			// yes this is ugly, feel free to suggest a better way
-			require_once(dirname(__FILE__).'/getid3.php');
-			$getid3_temp = new getID3();
-			$tempdir = $getid3_temp->tempdir;
-			unset($getid3_temp);
+			if (include_once(dirname(__FILE__).'/getid3.php')) {
+				if ($getid3_temp = new getID3()) {
+					if ($getid3_temp_tempdir = $getid3_temp->tempdir) {
+						$tempdir = $getid3_temp_tempdir;
+					}
+					unset($getid3_temp, $getid3_temp_tempdir);
+				}
+			}
 		}
 		$GetDataImageSize = false;
 		if ($tempfilename = tempnam($tempdir, 'gI3')) {
@@ -1166,6 +1187,11 @@ class getid3_lib
 				fwrite($tmp, $imgData);
 				fclose($tmp);
 				$GetDataImageSize = @getimagesize($tempfilename, $imageinfo);
+				if (($GetDataImageSize === false) || !isset($GetDataImageSize[0]) || !isset($GetDataImageSize[1])) {
+					return false;
+				}
+				$GetDataImageSize['height'] = $GetDataImageSize[0];
+				$GetDataImageSize['width']  = $GetDataImageSize[1];
 			}
 			unlink($tempfilename);
 		}

--- a/3rdparty/getID3/getid3/getid3.php
+++ b/3rdparty/getID3/getid3/getid3.php
@@ -109,7 +109,7 @@ class getID3
 	protected $startup_error   = '';
 	protected $startup_warning = '';
 
-	const VERSION           = '1.9.12-201602240818';
+	const VERSION           = '1.9.12-oc_music_app';
 	const FREAD_BUFFER_SIZE = 32768;
 
 	const ATTACHMENTS_NONE   = false;
@@ -1699,7 +1699,23 @@ abstract class getid3_handler {
 		if (!getid3_lib::intValueSupported($pos)) {
 			throw new getid3_exception('cannot fread('.$bytes.' from '.$this->ftell().') because beyond PHP filesystem limit', 10);
 		}
-		return fread($this->getid3->fp, $bytes);
+
+		//return fread($this->getid3->fp, $bytes);
+		/*
+		* http://www.getid3.org/phpBB3/viewtopic.php?t=1930
+		* "I found out that the root cause for the problem was how getID3 uses the PHP system function fread().
+		* It seems to assume that fread() would always return as many bytes as were requested.
+		* However, according the PHP manual (http://php.net/manual/en/function.fread.php), this is the case only with regular local files, but not e.g. with Linux pipes.
+		* The call may return only part of the requested data and a new call is needed to get more."
+		*/
+		$contents = '';
+		do {
+			$part = fread($this->getid3->fp, $bytes);
+			$partLength  = strlen($part);
+			$bytes      -= $partLength;
+			$contents   .= $part;
+		} while (($bytes > 0) && ($partLength > 0));
+		return $contents;
 	}
 
 	protected function fseek($bytes, $whence=SEEK_SET) {

--- a/3rdparty/getID3/getid3/getid3.php
+++ b/3rdparty/getID3/getid3/getid3.php
@@ -28,7 +28,7 @@ $temp_dir = ini_get('upload_tmp_dir');
 if ($temp_dir && (!is_dir($temp_dir) || !is_readable($temp_dir))) {
 	$temp_dir = '';
 }
-if (!$temp_dir) {
+if (!$temp_dir && function_exists('sys_get_temp_dir')) { // sys_get_temp_dir added in PHP v5.2.1
 	// sys_get_temp_dir() may give inaccessible temp dir, e.g. with open_basedir on virtual hosts
 	$temp_dir = sys_get_temp_dir();
 }
@@ -109,7 +109,7 @@ class getID3
 	protected $startup_error   = '';
 	protected $startup_warning = '';
 
-	const VERSION           = '1.9.8-20140511';
+	const VERSION           = '1.9.12-201602240818';
 	const FREAD_BUFFER_SIZE = 32768;
 
 	const ATTACHMENTS_NONE   = false;
@@ -243,7 +243,7 @@ class getID3
 	}
 
 
-	public function openfile($filename) {
+	public function openfile($filename, $filesize=null) {
 		try {
 			if (!empty($this->startup_error)) {
 				throw new getid3_exception($this->startup_error);
@@ -256,7 +256,7 @@ class getID3
 			$this->filename = $filename;
 			$this->info = array();
 			$this->info['GETID3_VERSION']   = $this->version();
-			$this->info['php_memory_limit'] = $this->memory_limit;
+			$this->info['php_memory_limit'] = (($this->memory_limit > 0) ? $this->memory_limit : false);
 
 			// remote files not supported
 			if (preg_match('/^(ht|f)tp:\/\//', $filename)) {
@@ -287,7 +287,7 @@ class getID3
 				throw new getid3_exception('Could not open "'.$filename.'" ('.implode('; ', $errormessagelist).')');
 			}
 
-			$this->info['filesize'] = filesize($filename);
+			$this->info['filesize'] = (!is_null($filesize) ? $filesize : filesize($filename));
 			// set redundant parameters - might be needed in some include file
 			// filenames / filepaths in getID3 are always expressed with forward slashes (unix-style) for both Windows and other to try and minimize confusion
 			$filename = str_replace('\\', '/', $filename);
@@ -342,9 +342,9 @@ class getID3
 	}
 
 	// public: analyze file
-	public function analyze($filename) {
+	public function analyze($filename, $filesize=null, $original_filename='') {
 		try {
-			if (!$this->openfile($filename)) {
+			if (!$this->openfile($filename, $filesize)) {
 				return $this->info;
 			}
 
@@ -389,7 +389,7 @@ class getID3
 			$formattest = fread($this->fp, 32774);
 
 			// determine format
-			$determined_format = $this->GetFileFormat($formattest, $filename);
+			$determined_format = $this->GetFileFormat($formattest, ($original_filename ? $original_filename : $filename));
 
 			// unable to determine file format
 			if (!$determined_format) {
@@ -634,6 +634,14 @@ class getID3
 							'mime_type' => 'audio/xmms-bonk',
 						),
 
+				// DSF  - audio       - Direct Stream Digital (DSD) Storage Facility files (DSF) - https://en.wikipedia.org/wiki/Direct_Stream_Digital
+				'dsf'  => array(
+							'pattern'   => '^DSD ',  // including trailing space: 44 53 44 20
+							'group'     => 'audio',
+							'module'    => 'dsf',
+							'mime_type' => 'audio/dsd',
+						),
+
 				// DSS  - audio       - Digital Speech Standard
 				'dss'  => array(
 							'pattern'   => '^[\x02-\x03]ds[s2]',
@@ -876,7 +884,7 @@ class getID3
 							'pattern'   => '^(RIFF|SDSS|FORM)',
 							'group'     => 'audio-video',
 							'module'    => 'riff',
-							'mime_type' => 'audio/x-wave',
+							'mime_type' => 'audio/x-wav',
 							'fail_ape'  => 'WARNING',
 						),
 
@@ -1234,6 +1242,29 @@ class getID3
 						$this->info['tags_html'][$tag_name][$tag_key] = getid3_lib::recursiveMultiByteCharString2HTML($valuearray, $encoding);
 					}
 				}
+
+				// ID3v1 encoding detection hack start
+				// ID3v1 is defined as always using ISO-8859-1 encoding, but it is not uncommon to find files tagged with ID3v1 using Windows-1251 or other character sets
+				// Since ID3v1 has no concept of character sets there is no certain way to know we have the correct non-ISO-8859-1 character set, but we can guess
+				if ($comment_name == 'id3v1') {
+					if ($encoding == 'ISO-8859-1') {
+						if (function_exists('iconv')) {
+							foreach ($this->info['tags'][$tag_name] as $tag_key => $valuearray) {
+								foreach ($valuearray as $key => $value) {
+									if (preg_match('#^[\\x80-\\xFF]+$#', $value)) {
+										foreach (array('windows-1251', 'KOI8-R') as $id3v1_bad_encoding) {
+											if (@iconv($id3v1_bad_encoding, $id3v1_bad_encoding, $value) === $value) {
+												$encoding = $id3v1_bad_encoding;
+												break 3;
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+				// ID3v1 encoding detection hack end
 
 				$this->CharConvert($this->info['tags'][$tag_name], $encoding);           // only copy gets converted!
 			}

--- a/3rdparty/getID3/getid3/module.archive.gzip.php
+++ b/3rdparty/getID3/getid3/module.archive.gzip.php
@@ -36,7 +36,7 @@ class getid3_gzip extends getid3_handler {
 		//|ID1|ID2|CM |FLG|     MTIME     |XFL|OS |
 		//+---+---+---+---+---+---+---+---+---+---+
 
-		if ($info['filesize'] > $info['php_memory_limit']) {
+		if ($info['php_memory_limit'] && ($info['filesize'] > $info['php_memory_limit'])) {
 			$info['error'][] = 'File is too large ('.number_format($info['filesize']).' bytes) to read into memory (limit: '.number_format($info['php_memory_limit'] / 1048576).'MB)';
 			return false;
 		}
@@ -56,7 +56,7 @@ class getid3_gzip extends getid3_handler {
 				$attr = unpack($unpack_header, substr($buf, 0, $start_length));
 				if (!$this->get_os_type(ord($attr['os']))) {
 					// Merge member with previous if wrong OS type
-					$arr_members[$i - 1] .= $buf;
+					$arr_members[($i - 1)] .= $buf;
 					$arr_members[$i] = '';
 					$is_wrong_members = true;
 					continue;

--- a/3rdparty/getID3/getid3/module.audio-video.flv.php
+++ b/3rdparty/getID3/getid3/module.audio-video.flv.php
@@ -541,7 +541,7 @@ class AMFReader {
 			// Long string
 			default:
 				$value = '(unknown or unsupported data type)';
-			break;
+				break;
 		}
 
 		return $value;

--- a/3rdparty/getID3/getid3/module.audio-video.matroska.php
+++ b/3rdparty/getID3/getid3/module.audio-video.matroska.php
@@ -457,6 +457,7 @@ class getid3_matroska extends getid3_handler
 
 							default:
 								$this->warning('Unhandled audio type "'.(isset($trackarray['CodecID']) ? $trackarray['CodecID'] : '').'"');
+								break;
 						}
 
 						$info['audio']['streams'][] = $track_info;
@@ -524,6 +525,7 @@ class getid3_matroska extends getid3_handler
 
 							default:
 								$this->unhandledElement('header', __LINE__, $element_data);
+								break;
 						}
 
 						unset($element_data['offset'], $element_data['end']);
@@ -562,6 +564,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('seekhead.seek', __LINE__, $sub_seek_entry);												}
+														break;
 											}
 
 											if ($seek_entry['target_id'] != EBML_ID_CLUSTER || !self::$hide_clusters) { // collect clusters only if required
@@ -571,6 +574,7 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('seekhead', __LINE__, $seek_entry);
+											break;
 									}
 								}
 								break;
@@ -653,6 +657,7 @@ class getid3_matroska extends getid3_handler
 
 																default:
 																	$this->unhandledElement('track.video', __LINE__, $sub_subelement);
+																	break;
 															}
 														}
 														break;
@@ -678,6 +683,7 @@ class getid3_matroska extends getid3_handler
 
 																default:
 																	$this->unhandledElement('track.audio', __LINE__, $sub_subelement);
+																	break;
 															}
 														}
 														break;
@@ -713,6 +719,7 @@ class getid3_matroska extends getid3_handler
 
 																						default:
 																							$this->unhandledElement('track.contentencodings.contentencoding.contentcompression', __LINE__, $sub_sub_sub_subelement);
+																							break;
 																					}
 																				}
 																				break;
@@ -736,24 +743,28 @@ class getid3_matroska extends getid3_handler
 
 																						default:
 																							$this->unhandledElement('track.contentencodings.contentencoding.contentcompression', __LINE__, $sub_sub_sub_subelement);
+																							break;
 																					}
 																				}
 																				break;
 
 																			default:
 																				$this->unhandledElement('track.contentencodings.contentencoding', __LINE__, $sub_sub_subelement);
+																				break;
 																		}
 																	}
 																	break;
 
 																default:
 																	$this->unhandledElement('track.contentencodings', __LINE__, $sub_subelement);
+																	break;
 															}
 														}
 														break;
 
 													default:
 														$this->unhandledElement('track', __LINE__, $subelement);
+														break;
 												}
 											}
 
@@ -762,6 +773,7 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('tracks', __LINE__, $track_entry);
+											break;
 									}
 								}
 								break;
@@ -825,6 +837,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('info.chaptertranslate', __LINE__, $sub_subelement);
+														break;
 												}
 											}
 											$info_entry[$subelement['id_name']] = $chaptertranslate_entry;
@@ -832,6 +845,7 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('info', __LINE__, $subelement);
+											break;
 									}
 								}
 								$info['matroska']['info'][] = $info_entry;
@@ -868,6 +882,7 @@ class getid3_matroska extends getid3_handler
 
 																default:
 																	$this->unhandledElement('cues.cuepoint.cuetrackpositions', __LINE__, $sub_sub_subelement);
+																	break;
 															}
 														}
 														$cuepoint_entry[$sub_subelement['id_name']][] = $cuetrackpositions_entry;
@@ -879,6 +894,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('cues.cuepoint', __LINE__, $sub_subelement);
+														break;
 												}
 											}
 											$cues_entry[] = $cuepoint_entry;
@@ -886,6 +902,7 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('cues', __LINE__, $subelement);
+											break;
 									}
 								}
 								$info['matroska']['cues'] = $cues_entry;
@@ -927,6 +944,7 @@ class getid3_matroska extends getid3_handler
 
 																default:
 																	$this->unhandledElement('tags.tag.targets', __LINE__, $sub_sub_subelement);
+																	break;
 															}
 														}
 														$tag_entry[$sub_subelement['id_name']] = $targets_entry;
@@ -938,6 +956,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('tags.tag', __LINE__, $sub_subelement);
+														break;
 												}
 											}
 											$tags_entry[] = $tag_entry;
@@ -945,6 +964,7 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('tags', __LINE__, $subelement);
+											break;
 									}
 								}
 								$info['matroska']['tags'] = $tags_entry;
@@ -985,6 +1005,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('attachments.attachedfile', __LINE__, $sub_subelement);
+														break;
 												}
 											}
 											$info['matroska']['attachments'][] = $attachedfile_entry;
@@ -992,6 +1013,7 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('attachments', __LINE__, $subelement);
+											break;
 									}
 								}
 								break;
@@ -1051,6 +1073,7 @@ class getid3_matroska extends getid3_handler
 
 																			default:
 																				$this->unhandledElement('chapters.editionentry.chapteratom.chaptertrack', __LINE__, $sub_sub_sub_subelement);
+																				break;
 																		}
 																	}
 																	$chapteratom_entry[$sub_sub_subelement['id_name']][] = $chaptertrack_entry;
@@ -1070,6 +1093,7 @@ class getid3_matroska extends getid3_handler
 
 																			default:
 																				$this->unhandledElement('chapters.editionentry.chapteratom.chapterdisplay', __LINE__, $sub_sub_sub_subelement);
+																				break;
 																		}
 																	}
 																	$chapteratom_entry[$sub_sub_subelement['id_name']][] = $chapterdisplay_entry;
@@ -1077,6 +1101,7 @@ class getid3_matroska extends getid3_handler
 
 																default:
 																	$this->unhandledElement('chapters.editionentry.chapteratom', __LINE__, $sub_sub_subelement);
+																	break;
 															}
 														}
 														$editionentry_entry[$sub_subelement['id_name']][] = $chapteratom_entry;
@@ -1084,6 +1109,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('chapters.editionentry', __LINE__, $sub_subelement);
+														break;
 												}
 											}
 											$info['matroska']['chapters'][] = $editionentry_entry;
@@ -1091,6 +1117,7 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('chapters', __LINE__, $subelement);
+											break;
 									}
 								}
 								break;
@@ -1119,6 +1146,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('cluster.silenttracks', __LINE__, $sub_subelement);
+														break;
 												}
 											}
 											$cluster_entry[$subelement['id_name']][] = $cluster_silent_tracks;
@@ -1149,6 +1177,7 @@ class getid3_matroska extends getid3_handler
 
 													default:
 														$this->unhandledElement('clusters.blockgroup', __LINE__, $sub_subelement);
+														break;
 												}
 											}
 											$cluster_entry[$subelement['id_name']][] = $cluster_block_group;
@@ -1160,6 +1189,7 @@ class getid3_matroska extends getid3_handler
 
 										default:
 											$this->unhandledElement('cluster', __LINE__, $subelement);
+											break;
 									}
 									$this->current_offset = $subelement['end'];
 								}
@@ -1181,12 +1211,14 @@ class getid3_matroska extends getid3_handler
 
 							default:
 								$this->unhandledElement('segment', __LINE__, $element_data);
+								break;
 						}
 					}
 					break;
 
 				default:
 					$this->unhandledElement('root', __LINE__, $top_element);
+					break;
 			}
 		}
 	}
@@ -1339,6 +1371,7 @@ class getid3_matroska extends getid3_handler
 
 				default:
 					$this->unhandledElement('tag.simpletag', __LINE__, $element);
+					break;
 			}
 		}
 

--- a/3rdparty/getID3/getid3/module.audio-video.riff.php
+++ b/3rdparty/getID3/getid3/module.audio-video.riff.php
@@ -1170,9 +1170,16 @@ class getid3_riff extends getid3_handler {
 				}
 				break;
 
+			case 'WEBP':
+				// https://developers.google.com/speed/webp/docs/riff_container
+				$info['fileformat'] = 'webp';
+				$info['mime_type']  = 'image/webp';
+
+$info['error'][] = 'WebP image parsing not supported in this version of getID3()';
+				break;
 
 			default:
-				$info['error'][] = 'Unknown RIFF type: expecting one of (WAVE|RMP3|AVI |CDDA|AIFF|AIFC|8SVX|CDXA), found "'.$RIFFsubtype.'" instead';
+				$info['error'][] = 'Unknown RIFF type: expecting one of (WAVE|RMP3|AVI |CDDA|AIFF|AIFC|8SVX|CDXA|WEBP), found "'.$RIFFsubtype.'" instead';
 				//unset($info['fileformat']);
 		}
 

--- a/3rdparty/getID3/getid3/module.audio.dsf.php
+++ b/3rdparty/getID3/getid3/module.audio.dsf.php
@@ -1,0 +1,133 @@
+<?php
+/////////////////////////////////////////////////////////////////
+/// getID3() by James Heinrich <info@getid3.org>               //
+//  available at http://getid3.sourceforge.net                 //
+//            or http://www.getid3.org                         //
+//          also https://github.com/JamesHeinrich/getID3       //
+/////////////////////////////////////////////////////////////////
+// See readme.txt for more details                             //
+/////////////////////////////////////////////////////////////////
+//                                                             //
+// module.audio.dsf.php                                        //
+// module for analyzing dsf/DSF Audio files                    //
+// dependencies: module.tag.id3v2.php                          //
+//                                                            ///
+/////////////////////////////////////////////////////////////////
+
+getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.id3v2.php', __FILE__, true);
+
+class getid3_dsf extends getid3_handler
+{
+
+	public function Analyze() {
+		$info = &$this->getid3->info;
+
+		$info['fileformat']            = 'dsf';
+		$info['audio']['dataformat']   = 'dsf';
+		$info['audio']['lossless']     = true;
+		$info['audio']['bitrate_mode'] = 'cbr';
+
+		$this->fseek($info['avdataoffset']);
+		$dsfheader = $this->fread(28 + 12);
+
+		$headeroffset = 0;
+		$info['dsf']['dsd']['magic'] = substr($dsfheader, $headeroffset, 4);
+		$headeroffset += 4;
+		$magic = 'DSD ';
+		if ($info['dsf']['dsd']['magic'] != $magic) {
+			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$info['avdataoffset'].', found "'.getid3_lib::PrintHexBytes($info['dsf']['dsd']['magic']).'"';
+			unset($info['fileformat']);
+			unset($info['audio']);
+			unset($info['dsf']);
+			return false;
+		}
+		$info['dsf']['dsd']['dsd_chunk_size']     = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 8)); // should be 28
+		$headeroffset += 8;
+		$info['dsf']['dsd']['dsf_file_size']      = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 8));
+		$headeroffset += 8;
+		$info['dsf']['dsd']['meta_chunk_offset']  = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 8));
+		$headeroffset += 8;
+
+
+		$info['dsf']['fmt']['magic'] = substr($dsfheader, $headeroffset, 4);
+		$headeroffset += 4;
+		$magic = 'fmt ';
+		if ($info['dsf']['fmt']['magic'] != $magic) {
+			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$headeroffset.', found "'.getid3_lib::PrintHexBytes($info['dsf']['fmt']['magic']).'"';
+			return false;
+		}
+		$info['dsf']['fmt']['fmt_chunk_size']     = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 8));  // usually 52 bytes
+		$headeroffset += 8;
+		$dsfheader .= $this->fread($info['dsf']['fmt']['fmt_chunk_size'] - 12 + 12);  // we have already read the entire DSD chunk, plus 12 bytes of FMT. We now want to read the size of FMT, plus 12 bytes into the next chunk to get magic and size.
+		if (strlen($dsfheader) != ($info['dsf']['dsd']['dsd_chunk_size'] + $info['dsf']['fmt']['fmt_chunk_size'] + 12)) {
+			$info['error'][] = 'Expecting '.($info['dsf']['dsd']['dsd_chunk_size'] + $info['dsf']['fmt']['fmt_chunk_size']).' bytes header, found '.strlen($dsfheader).' bytes';
+			return false;
+		}
+		$info['dsf']['fmt']['format_version']     = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));  // usually "1"
+		$headeroffset += 4;
+		$info['dsf']['fmt']['format_id']          = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));  // usually "0" = "DSD Raw"
+		$headeroffset += 4;
+		$info['dsf']['fmt']['channel_type_id']    = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));
+		$headeroffset += 4;
+		$info['dsf']['fmt']['channels']           = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));
+		$headeroffset += 4;
+		$info['dsf']['fmt']['sample_rate']        = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));
+		$headeroffset += 4;
+		$info['dsf']['fmt']['bits_per_sample']    = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));
+		$headeroffset += 4;
+		$info['dsf']['fmt']['sample_count']       = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 8));
+		$headeroffset += 8;
+		$info['dsf']['fmt']['channel_block_size'] = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4));
+		$headeroffset += 4;
+		$info['dsf']['fmt']['reserved']           = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 4)); // zero-filled
+		$headeroffset += 4;
+
+
+		$info['dsf']['data']['magic'] = substr($dsfheader, $headeroffset, 4);
+		$headeroffset += 4;
+		$magic = 'data';
+		if ($info['dsf']['data']['magic'] != $magic) {
+			$info['error'][] = 'Expecting "'.getid3_lib::PrintHexBytes($magic).'" at offset '.$headeroffset.', found "'.getid3_lib::PrintHexBytes($info['dsf']['data']['magic']).'"';
+			return false;
+		}
+		$info['dsf']['data']['data_chunk_size']    = getid3_lib::LittleEndian2Int(substr($dsfheader, $headeroffset, 8));
+		$headeroffset += 8;
+		$info['avdataoffset'] = $headeroffset;
+		$info['avdataend']    = $info['avdataoffset'] + $info['dsf']['data']['data_chunk_size'];
+
+
+		if ($info['dsf']['dsd']['meta_chunk_offset'] > 0) {
+			$getid3_id3v2 = new getid3_id3v2($this->getid3);
+			$getid3_id3v2->StartingOffset = $info['dsf']['dsd']['meta_chunk_offset'];
+			$getid3_id3v2->Analyze();
+			unset($getid3_id3v2);
+		}
+
+
+		$info['dsf']['fmt']['channel_type'] = $this->DSFchannelTypeLookup($info['dsf']['fmt']['channel_type_id']);
+		$info['audio']['channelmode']       = $info['dsf']['fmt']['channel_type'];
+		$info['audio']['bits_per_sample']   = $info['dsf']['fmt']['bits_per_sample'];
+		$info['audio']['sample_rate']       = $info['dsf']['fmt']['sample_rate'];
+		$info['audio']['channels']          = $info['dsf']['fmt']['channels'];
+		$info['audio']['bitrate']           = $info['audio']['bits_per_sample'] * $info['audio']['sample_rate'] * $info['audio']['channels'];
+		$info['playtime_seconds']           = ($info['dsf']['data']['data_chunk_size'] * 8) / $info['audio']['bitrate'];
+
+		return true;
+	}
+
+
+	public static function DSFchannelTypeLookup($channel_type_id) {
+		static $DSFchannelTypeLookup = array(
+			                  // interleaving order:
+			1 => 'mono',      // 1: Mono
+			2 => 'stereo',    // 1: Front-Left; 2: Front-Right
+			3 => '3-channel', // 1: Front-Left; 2: Front-Right; 3: Center
+			4 => 'quad',      // 1: Front-Left; 2: Front-Right; 3: Back-Left; 4: Back-Right
+			5 => '4-channel', // 1: Front-Left; 2: Front-Right; 3: Center;    4: Low-Frequency
+			6 => '5-channel', // 1: Front-Left; 2: Front-Right; 3: Center;    4: Back-Left      5: Back-Right
+			7 => '5.1',       // 1: Front-Left; 2: Front-Right; 3: Center;    4: Low-Frequency; 5: Back-Left;  6: Back-Right
+		);
+		return (isset($DSFchannelTypeLookup[$channel_type_id]) ? $DSFchannelTypeLookup[$channel_type_id] : '');
+	}
+
+}

--- a/3rdparty/getID3/getid3/module.audio.flac.php
+++ b/3rdparty/getID3/getid3/module.audio.flac.php
@@ -135,7 +135,17 @@ class getid3_flac extends getid3_handler
 		if (isset($info['flac']['PICTURE']) && ($this->getid3->option_save_attachments !== getID3::ATTACHMENTS_NONE)) {
 			foreach ($info['flac']['PICTURE'] as $entry) {
 				if (!empty($entry['data'])) {
-					$info['flac']['comments']['picture'][] = array('image_mime'=>$entry['image_mime'], 'data'=>$entry['data']);
+					if (!isset($info['flac']['comments']['picture'])) {
+						$info['flac']['comments']['picture'] = array();
+					}
+					$comments_picture_data = array();
+					foreach (array('data', 'image_mime', 'image_width', 'image_height', 'imagetype', 'picturetype', 'description', 'datalength') as $picture_key) {
+						if (isset($entry[$picture_key])) {
+							$comments_picture_data[$picture_key] = $entry[$picture_key];
+						}
+					}
+					$info['flac']['comments']['picture'][] = $comments_picture_data;
+					unset($comments_picture_data);
 				}
 			}
 		}
@@ -343,25 +353,25 @@ class getid3_flac extends getid3_handler
 		$info = &$this->getid3->info;
 
 		$picture['typeid']         = getid3_lib::BigEndian2Int($this->fread(4));
-		$picture['type']           = self::pictureTypeLookup($picture['typeid']);
+		$picture['picturetype']    = self::pictureTypeLookup($picture['typeid']);
 		$picture['image_mime']     = $this->fread(getid3_lib::BigEndian2Int($this->fread(4)));
 		$descr_length              = getid3_lib::BigEndian2Int($this->fread(4));
 		if ($descr_length) {
 			$picture['description'] = $this->fread($descr_length);
 		}
-		$picture['width']          = getid3_lib::BigEndian2Int($this->fread(4));
-		$picture['height']         = getid3_lib::BigEndian2Int($this->fread(4));
+		$picture['image_width']    = getid3_lib::BigEndian2Int($this->fread(4));
+		$picture['image_height']   = getid3_lib::BigEndian2Int($this->fread(4));
 		$picture['color_depth']    = getid3_lib::BigEndian2Int($this->fread(4));
 		$picture['colors_indexed'] = getid3_lib::BigEndian2Int($this->fread(4));
-		$data_length               = getid3_lib::BigEndian2Int($this->fread(4));
+		$picture['datalength']     = getid3_lib::BigEndian2Int($this->fread(4));
 
 		if ($picture['image_mime'] == '-->') {
-			$picture['data'] = $this->fread($data_length);
+			$picture['data'] = $this->fread($picture['datalength']);
 		} else {
 			$picture['data'] = $this->saveAttachment(
-				str_replace('/', '_', $picture['type']).'_'.$this->ftell(),
+				str_replace('/', '_', $picture['picturetype']).'_'.$this->ftell(),
 				$this->ftell(),
-				$data_length,
+				$picture['datalength'],
 				$picture['image_mime']);
 		}
 

--- a/3rdparty/getID3/getid3/module.audio.mp3.php
+++ b/3rdparty/getID3/getid3/module.audio.mp3.php
@@ -437,7 +437,6 @@ class getid3_mp3 extends getid3_handler
 		// and $cc... is the audio data
 
 		$head4 = substr($headerstring, 0, 4);
-
 		static $MPEGaudioHeaderDecodeCache = array();
 		if (isset($MPEGaudioHeaderDecodeCache[$head4])) {
 			$MPEGheaderRawArray = $MPEGaudioHeaderDecodeCache[$head4];
@@ -648,9 +647,20 @@ class getid3_mp3 extends getid3_handler
 				}
 
 				//if (($thisfile_mpeg_audio['bitrate'] == 'free') && !empty($thisfile_mpeg_audio['VBR_frames']) && !empty($thisfile_mpeg_audio['VBR_bytes'])) {
-				if (!empty($thisfile_mpeg_audio['VBR_frames']) && !empty($thisfile_mpeg_audio['VBR_bytes'])) {
+				//if (!empty($thisfile_mpeg_audio['VBR_frames']) && !empty($thisfile_mpeg_audio['VBR_bytes'])) {
+				if (!empty($thisfile_mpeg_audio['VBR_frames'])) {
+					$used_filesize  = 0;
+					if (!empty($thisfile_mpeg_audio['VBR_bytes'])) {
+						$used_filesize = $thisfile_mpeg_audio['VBR_bytes'];
+					} elseif (!empty($info['filesize'])) {
+						$used_filesize  = $info['filesize'];
+						$used_filesize -= intval(@$info['id3v2']['headerlength']);
+						$used_filesize -= (isset($info['id3v1']) ? 128 : 0);
+						$used_filesize -= (isset($info['tag_offset_end']) ? $info['tag_offset_end'] - $info['tag_offset_start'] : 0);
+						$info['warning'][] = 'MP3.Xing header missing VBR_bytes, assuming MPEG audio portion of file is '.number_format($used_filesize).' bytes';
+					}
 
-					$framelengthfloat = $thisfile_mpeg_audio['VBR_bytes'] / $thisfile_mpeg_audio['VBR_frames'];
+					$framelengthfloat = $used_filesize / $thisfile_mpeg_audio['VBR_frames'];
 
 					if ($thisfile_mpeg_audio['layer'] == '1') {
 						// BitRate = (((FrameLengthInBytes / 4) - Padding) * SampleRate) / 12
@@ -948,7 +958,7 @@ class getid3_mp3 extends getid3_handler
 					}
 					$thisfile_mpeg_audio['VBR_bitrate'] = (isset($thisfile_mpeg_audio['VBR_bytes']) ? (($thisfile_mpeg_audio['VBR_bytes'] / $thisfile_mpeg_audio['VBR_frames']) * 8) * ($info['audio']['sample_rate'] / $bytes_per_frame) : 0);
 					if ($thisfile_mpeg_audio['VBR_bitrate'] > 0) {
-						$info['audio']['bitrate']         = $thisfile_mpeg_audio['VBR_bitrate'];
+						$info['audio']['bitrate']       = $thisfile_mpeg_audio['VBR_bitrate'];
 						$thisfile_mpeg_audio['bitrate'] = $thisfile_mpeg_audio['VBR_bitrate']; // to avoid confusion
 					}
 					break;

--- a/3rdparty/getID3/getid3/module.audio.ogg.php
+++ b/3rdparty/getID3/getid3/module.audio.ogg.php
@@ -63,6 +63,12 @@ class getid3_ogg extends getid3_handler
 
 			$this->ParseVorbisPageHeader($filedata, $filedataoffset, $oggpageinfo);
 
+		} elseif (substr($filedata, 0, 8) == 'OpusHead') {
+
+			if( $this->ParseOpusPageHeader($filedata, $filedataoffset, $oggpageinfo) == false ) {
+				return false;
+			}
+
 		} elseif (substr($filedata, 0, 8) == 'Speex   ') {
 
 			// http://www.speex.org/manual/node10.html
@@ -255,7 +261,7 @@ $info['warning'][] = 'Ogg Theora (v3) not fully supported in this version of get
 
 		} else {
 
-			$info['error'][] = 'Expecting either "Speex   " or "vorbis" identifier strings, found "'.substr($filedata, 0, 8).'"';
+			$info['error'][] = 'Expecting either "Speex   ", "OpusHead" or "vorbis" identifier strings, found "'.substr($filedata, 0, 8).'"';
 			unset($info['ogg']);
 			unset($info['mime_type']);
 			return false;
@@ -288,8 +294,19 @@ $info['warning'][] = 'Ogg Theora (v3) not fully supported in this version of get
 				$this->fseek($info['ogg']['pageheader'][$oggpageinfo['page_seqno']]['page_length'], SEEK_CUR);
 				$this->ParseVorbisComments();
 				break;
-		}
 
+			case 'opus':
+				$filedata = $this->fread($info['ogg']['pageheader'][$oggpageinfo['page_seqno']]['page_length']);
+				$info['ogg']['pageheader'][$oggpageinfo['page_seqno']]['stream_type'] = substr($filedata, 0, 8); // hard-coded to 'OpusTags'
+				if(substr($filedata, 0, 8)  != 'OpusTags') {
+					$info['error'][] = 'Expected "OpusTags" as header but got "'.substr($filedata, 0, 8).'"';
+					return false;
+				}
+
+				$this->ParseVorbisComments();
+				break;
+
+		}
 
 		// Last Page - Number of Samples
 		if (!getid3_lib::intValueSupported($info['avdataend'])) {
@@ -409,6 +426,57 @@ $info['warning'][] = 'Ogg Theora (v3) not fully supported in this version of get
 		return true;
 	}
 
+	// http://tools.ietf.org/html/draft-ietf-codec-oggopus-03
+	public function ParseOpusPageHeader(&$filedata, &$filedataoffset, &$oggpageinfo) {
+		$info = &$this->getid3->info;
+		$info['audio']['dataformat']   = 'opus';
+		$info['mime_type']             = 'audio/ogg; codecs=opus';
+
+		/** @todo find a usable way to detect abr (vbr that is padded to be abr) */
+		$info['audio']['bitrate_mode'] = 'vbr';
+
+		$info['audio']['lossless']     = false;
+
+		$info['ogg']['pageheader']['opus']['opus_magic'] = substr($filedata, $filedataoffset, 8); // hard-coded to 'OpusHead'
+		$filedataoffset += 8;
+		$info['ogg']['pageheader']['opus']['version']    = getid3_lib::LittleEndian2Int(substr($filedata, $filedataoffset,  1));
+		$filedataoffset += 1;
+
+		if ($info['ogg']['pageheader']['opus']['version'] < 1 || $info['ogg']['pageheader']['opus']['version'] > 15) {
+			$info['error'][] = 'Unknown opus version number (only accepting 1-15)';
+			return false;
+		}
+
+		$info['ogg']['pageheader']['opus']['out_channel_count'] = getid3_lib::LittleEndian2Int(substr($filedata, $filedataoffset,  1));
+		$filedataoffset += 1;
+
+		if ($info['ogg']['pageheader']['opus']['out_channel_count'] == 0) {
+			$info['error'][] = 'Invalid channel count in opus header (must not be zero)';
+			return false;
+		}
+
+		$info['ogg']['pageheader']['opus']['pre_skip'] = getid3_lib::LittleEndian2Int(substr($filedata, $filedataoffset,  2));
+		$filedataoffset += 2;
+
+		$info['ogg']['pageheader']['opus']['sample_rate'] = getid3_lib::LittleEndian2Int(substr($filedata, $filedataoffset,  4));
+		$filedataoffset += 4;
+
+		//$info['ogg']['pageheader']['opus']['output_gain'] = getid3_lib::LittleEndian2Int(substr($filedata, $filedataoffset,  2));
+		//$filedataoffset += 2;
+
+		//$info['ogg']['pageheader']['opus']['channel_mapping_family'] = getid3_lib::LittleEndian2Int(substr($filedata, $filedataoffset,  1));
+		//$filedataoffset += 1;
+
+		$info['opus']['opus_version']      = $info['ogg']['pageheader']['opus']['version'];
+		$info['opus']['sample_rate']       = $info['ogg']['pageheader']['opus']['sample_rate'];
+		$info['opus']['out_channel_count'] = $info['ogg']['pageheader']['opus']['out_channel_count'];
+
+		$info['audio']['channels']      = $info['opus']['out_channel_count'];
+		$info['audio']['sample_rate']   = $info['opus']['sample_rate'];
+		return true;
+	}
+
+
 	public function ParseOggPageHeader() {
 		// http://xiph.org/ogg/vorbis/doc/framing.html
 		$oggheader['page_start_offset'] = $this->ftell(); // where we started from in the file
@@ -471,6 +539,7 @@ $info['warning'][] = 'Ogg Theora (v3) not fully supported in this version of get
 		switch ($info['audio']['dataformat']) {
 			case 'vorbis':
 			case 'speex':
+			case 'opus':
 				$CommentStartOffset = $info['ogg']['pageheader'][$VorbisCommentPage]['page_start_offset'];  // Second Ogg page, after header block
 				$this->fseek($CommentStartOffset);
 				$commentdataoffset = 27 + $info['ogg']['pageheader'][$VorbisCommentPage]['page_segments'];
@@ -479,6 +548,10 @@ $info['warning'][] = 'Ogg Theora (v3) not fully supported in this version of get
 				if ($info['audio']['dataformat'] == 'vorbis') {
 					$commentdataoffset += (strlen('vorbis') + 1);
 				}
+				else if ($info['audio']['dataformat'] == 'opus') {
+					$commentdataoffset += strlen('OpusTags');
+				}
+
 				break;
 
 			case 'flac':
@@ -489,6 +562,7 @@ $info['warning'][] = 'Ogg Theora (v3) not fully supported in this version of get
 
 			default:
 				return false;
+				break;
 		}
 
 		$VendorSize = getid3_lib::LittleEndian2Int(substr($commentdata, $commentdataoffset, 4));
@@ -508,7 +582,7 @@ $info['warning'][] = 'Ogg Theora (v3) not fully supported in this version of get
 			if ($i >= 10000) {
 				// https://github.com/owncloud/music/issues/212#issuecomment-43082336
 				$info['warning'][] = 'Unexpectedly large number ('.$CommentsCount.') of Ogg comments - breaking after reading '.$i.' comments';
-				break 2;
+				break;
 			}
 
 			$ThisFileInfo_ogg_comments_raw[$i]['dataoffset'] = $CommentStartOffset + $commentdataoffset;
@@ -621,8 +695,12 @@ $info['warning'][] = 'Ogg Theora (v3) not fully supported in this version of get
 					$ogg = new self($this->getid3);
 					$ogg->setStringMode($data);
 					$info['ogg']['comments']['picture'][] = array(
-						'image_mime' => $imageinfo['mime'],
-						'data'       => $ogg->saveAttachment('coverart', 0, strlen($data), $imageinfo['mime']),
+						'image_mime'   => $imageinfo['mime'],
+						'datalength'   => strlen($data),
+						'picturetype'  => 'cover art',
+						'image_height' => $imageinfo['height'],
+						'image_width'  => $imageinfo['width'],
+						'data'         => $ogg->saveAttachment('coverart', 0, strlen($data), $imageinfo['mime']),
 					);
 					unset($ogg);
 

--- a/3rdparty/getID3/getid3/module.graphic.png.php
+++ b/3rdparty/getID3/getid3/module.graphic.png.php
@@ -17,8 +17,10 @@
 
 class getid3_png extends getid3_handler
 {
+	public $max_data_bytes = 10000000; // if data chunk is larger than this do not read it completely (getID3 only needs the first few dozen bytes for parsing)
 
 	public function Analyze() {
+
 		$info = &$this->getid3->info;
 
 		// shortcut
@@ -44,14 +46,24 @@ class getid3_png extends getid3_handler
 
 		while ((($this->ftell() - (strlen($PNGfiledata) - $offset)) < $info['filesize'])) {
 			$chunk['data_length'] = getid3_lib::BigEndian2Int(substr($PNGfiledata, $offset, 4));
-			$offset += 4;
-			while (((strlen($PNGfiledata) - $offset) < ($chunk['data_length'] + 4)) && ($this->ftell() < $info['filesize'])) {
-				$PNGfiledata .= $this->fread($this->getid3->fread_buffer_size());
+			if ($chunk['data_length'] === false) {
+				$info['error'][] = 'Failed to read data_length at offset '.$offset;
+				return false;
 			}
-			$chunk['type_text']   =               substr($PNGfiledata, $offset, 4);
+			$offset += 4;
+			$truncated_data = false;
+			while (((strlen($PNGfiledata) - $offset) < ($chunk['data_length'] + 4)) && ($this->ftell() < $info['filesize'])) {
+				if (strlen($PNGfiledata) < $this->max_data_bytes) {
+					$PNGfiledata .= $this->fread($this->getid3->fread_buffer_size());
+				} else {
+					$info['warning'][] = 'At offset '.$offset.' chunk "'.substr($PNGfiledata, $offset, 4).'" exceeded max_data_bytes value of '.$this->max_data_bytes.', data chunk will be truncated at '.(strlen($PNGfiledata) - 8).' bytes';
+					break;
+				}
+			}
+			$chunk['type_text']   =                           substr($PNGfiledata, $offset, 4);
 			$offset += 4;
 			$chunk['type_raw']    = getid3_lib::BigEndian2Int($chunk['type_text']);
-			$chunk['data']        =               substr($PNGfiledata, $offset, $chunk['data_length']);
+			$chunk['data']        =                           substr($PNGfiledata, $offset, $chunk['data_length']);
 			$offset += $chunk['data_length'];
 			$chunk['crc']         = getid3_lib::BigEndian2Int(substr($PNGfiledata, $offset, 4));
 			$offset += 4;
@@ -162,7 +174,7 @@ class getid3_png extends getid3_handler
 
 				case 'iCCP': // Embedded ICC Profile
 					$thisfile_png_chunk_type_text['header']                  = $chunk;
-					list($profilename, $compressiondata)                                 = explode("\x00", $chunk['data'], 2);
+					list($profilename, $compressiondata)                     = explode("\x00", $chunk['data'], 2);
 					$thisfile_png_chunk_type_text['profile_name']            = $profilename;
 					$thisfile_png_chunk_type_text['compression_method']      = getid3_lib::BigEndian2Int(substr($compressiondata, 0, 1));
 					$thisfile_png_chunk_type_text['compression_profile']     = substr($compressiondata, 1);
@@ -173,7 +185,7 @@ class getid3_png extends getid3_handler
 
 				case 'tEXt': // Textual Data
 					$thisfile_png_chunk_type_text['header']  = $chunk;
-					list($keyword, $text)                                = explode("\x00", $chunk['data'], 2);
+					list($keyword, $text) = explode("\x00", $chunk['data'], 2);
 					$thisfile_png_chunk_type_text['keyword'] = $keyword;
 					$thisfile_png_chunk_type_text['text']    = $text;
 
@@ -183,7 +195,7 @@ class getid3_png extends getid3_handler
 
 				case 'zTXt': // Compressed Textual Data
 					$thisfile_png_chunk_type_text['header']                  = $chunk;
-					list($keyword, $otherdata)                                           = explode("\x00", $chunk['data'], 2);
+					list($keyword, $otherdata)                               = explode("\x00", $chunk['data'], 2);
 					$thisfile_png_chunk_type_text['keyword']                 = $keyword;
 					$thisfile_png_chunk_type_text['compression_method']      = getid3_lib::BigEndian2Int(substr($otherdata, 0, 1));
 					$thisfile_png_chunk_type_text['compressed_text']         = substr($otherdata, 1);
@@ -206,7 +218,7 @@ class getid3_png extends getid3_handler
 
 				case 'iTXt': // International Textual Data
 					$thisfile_png_chunk_type_text['header']                  = $chunk;
-					list($keyword, $otherdata)                                           = explode("\x00", $chunk['data'], 2);
+					list($keyword, $otherdata)                               = explode("\x00", $chunk['data'], 2);
 					$thisfile_png_chunk_type_text['keyword']                 = $keyword;
 					$thisfile_png_chunk_type_text['compression']             = (bool) getid3_lib::BigEndian2Int(substr($otherdata, 0, 1));
 					$thisfile_png_chunk_type_text['compression_method']      = getid3_lib::BigEndian2Int(substr($otherdata, 1, 1));
@@ -307,7 +319,7 @@ class getid3_png extends getid3_handler
 
 				case 'sPLT': // Suggested Palette
 					$thisfile_png_chunk_type_text['header']                           = $chunk;
-					list($palettename, $otherdata)                                                = explode("\x00", $chunk['data'], 2);
+					list($palettename, $otherdata)                                    = explode("\x00", $chunk['data'], 2);
 					$thisfile_png_chunk_type_text['palette_name']                     = $palettename;
 					$sPLToffset = 0;
 					$thisfile_png_chunk_type_text['sample_depth_bits']                = getid3_lib::BigEndian2Int(substr($otherdata, $sPLToffset, 1));

--- a/3rdparty/getID3/getid3/module.tag.apetag.php
+++ b/3rdparty/getID3/getid3/module.tag.apetag.php
@@ -138,58 +138,88 @@ class getid3_apetag extends getid3_handler
 			$thisfile_ape_items_current['flags'] = $this->parseAPEtagFlags($item_flags);
 			switch ($thisfile_ape_items_current['flags']['item_contents_raw']) {
 				case 0: // UTF-8
-				case 3: // Locator (URL, filename, etc), UTF-8 encoded
-					$thisfile_ape_items_current['data'] = explode("\x00", trim($thisfile_ape_items_current['data']));
+				case 2: // Locator (URL, filename, etc), UTF-8 encoded
+					$thisfile_ape_items_current['data'] = explode("\x00", $thisfile_ape_items_current['data']);
 					break;
 
-				default: // binary data
+				case 1:  // binary data
+				default:
 					break;
 			}
 
 			switch (strtolower($item_key)) {
+				// http://wiki.hydrogenaud.io/index.php?title=ReplayGain#MP3Gain
 				case 'replaygain_track_gain':
-					$thisfile_replaygain['track']['adjustment'] = (float) str_replace(',', '.', $thisfile_ape_items_current['data'][0]); // float casting will see "0,95" as zero!
-					$thisfile_replaygain['track']['originator'] = 'unspecified';
+					if (preg_match('#^[\\-\\+][0-9\\.,]{8}$#', $thisfile_ape_items_current['data'][0])) {
+						$thisfile_replaygain['track']['adjustment'] = (float) str_replace(',', '.', $thisfile_ape_items_current['data'][0]); // float casting will see "0,95" as zero!
+						$thisfile_replaygain['track']['originator'] = 'unspecified';
+					} else {
+						$info['warning'][] = 'MP3gainTrackGain value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"';
+					}
 					break;
 
 				case 'replaygain_track_peak':
-					$thisfile_replaygain['track']['peak']       = (float) str_replace(',', '.', $thisfile_ape_items_current['data'][0]); // float casting will see "0,95" as zero!
-					$thisfile_replaygain['track']['originator'] = 'unspecified';
-					if ($thisfile_replaygain['track']['peak'] <= 0) {
-						$info['warning'][] = 'ReplayGain Track peak from APEtag appears invalid: '.$thisfile_replaygain['track']['peak'].' (original value = "'.$thisfile_ape_items_current['data'][0].'")';
+					if (preg_match('#^[0-9\\.,]{8}$#', $thisfile_ape_items_current['data'][0])) {
+						$thisfile_replaygain['track']['peak']       = (float) str_replace(',', '.', $thisfile_ape_items_current['data'][0]); // float casting will see "0,95" as zero!
+						$thisfile_replaygain['track']['originator'] = 'unspecified';
+						if ($thisfile_replaygain['track']['peak'] <= 0) {
+							$info['warning'][] = 'ReplayGain Track peak from APEtag appears invalid: '.$thisfile_replaygain['track']['peak'].' (original value = "'.$thisfile_ape_items_current['data'][0].'")';
+						}
+					} else {
+						$info['warning'][] = 'MP3gainTrackPeak value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"';
 					}
 					break;
 
 				case 'replaygain_album_gain':
-					$thisfile_replaygain['album']['adjustment'] = (float) str_replace(',', '.', $thisfile_ape_items_current['data'][0]); // float casting will see "0,95" as zero!
-					$thisfile_replaygain['album']['originator'] = 'unspecified';
+					if (preg_match('#^[\\-\\+][0-9\\.,]{8}$#', $thisfile_ape_items_current['data'][0])) {
+						$thisfile_replaygain['album']['adjustment'] = (float) str_replace(',', '.', $thisfile_ape_items_current['data'][0]); // float casting will see "0,95" as zero!
+						$thisfile_replaygain['album']['originator'] = 'unspecified';
+					} else {
+						$info['warning'][] = 'MP3gainAlbumGain value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"';
+					}
 					break;
 
 				case 'replaygain_album_peak':
-					$thisfile_replaygain['album']['peak']       = (float) str_replace(',', '.', $thisfile_ape_items_current['data'][0]); // float casting will see "0,95" as zero!
-					$thisfile_replaygain['album']['originator'] = 'unspecified';
-					if ($thisfile_replaygain['album']['peak'] <= 0) {
-						$info['warning'][] = 'ReplayGain Album peak from APEtag appears invalid: '.$thisfile_replaygain['album']['peak'].' (original value = "'.$thisfile_ape_items_current['data'][0].'")';
+					if (preg_match('#^[0-9\\.,]{8}$#', $thisfile_ape_items_current['data'][0])) {
+						$thisfile_replaygain['album']['peak']       = (float) str_replace(',', '.', $thisfile_ape_items_current['data'][0]); // float casting will see "0,95" as zero!
+						$thisfile_replaygain['album']['originator'] = 'unspecified';
+						if ($thisfile_replaygain['album']['peak'] <= 0) {
+							$info['warning'][] = 'ReplayGain Album peak from APEtag appears invalid: '.$thisfile_replaygain['album']['peak'].' (original value = "'.$thisfile_ape_items_current['data'][0].'")';
+						}
+					} else {
+						$info['warning'][] = 'MP3gainAlbumPeak value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"';
 					}
 					break;
 
 				case 'mp3gain_undo':
-					list($mp3gain_undo_left, $mp3gain_undo_right, $mp3gain_undo_wrap) = explode(',', $thisfile_ape_items_current['data'][0]);
-					$thisfile_replaygain['mp3gain']['undo_left']  = intval($mp3gain_undo_left);
-					$thisfile_replaygain['mp3gain']['undo_right'] = intval($mp3gain_undo_right);
-					$thisfile_replaygain['mp3gain']['undo_wrap']  = (($mp3gain_undo_wrap == 'Y') ? true : false);
+					if (preg_match('#^[\\-\\+][0-9]{3},[\\-\\+][0-9]{3},[NW]$#', $thisfile_ape_items_current['data'][0])) {
+						list($mp3gain_undo_left, $mp3gain_undo_right, $mp3gain_undo_wrap) = explode(',', $thisfile_ape_items_current['data'][0]);
+						$thisfile_replaygain['mp3gain']['undo_left']  = intval($mp3gain_undo_left);
+						$thisfile_replaygain['mp3gain']['undo_right'] = intval($mp3gain_undo_right);
+						$thisfile_replaygain['mp3gain']['undo_wrap']  = (($mp3gain_undo_wrap == 'Y') ? true : false);
+					} else {
+						$info['warning'][] = 'MP3gainUndo value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"';
+					}
 					break;
 
 				case 'mp3gain_minmax':
-					list($mp3gain_globalgain_min, $mp3gain_globalgain_max) = explode(',', $thisfile_ape_items_current['data'][0]);
-					$thisfile_replaygain['mp3gain']['globalgain_track_min'] = intval($mp3gain_globalgain_min);
-					$thisfile_replaygain['mp3gain']['globalgain_track_max'] = intval($mp3gain_globalgain_max);
+					if (preg_match('#^[0-9]{3},[0-9]{3}$#', $thisfile_ape_items_current['data'][0])) {
+						list($mp3gain_globalgain_min, $mp3gain_globalgain_max) = explode(',', $thisfile_ape_items_current['data'][0]);
+						$thisfile_replaygain['mp3gain']['globalgain_track_min'] = intval($mp3gain_globalgain_min);
+						$thisfile_replaygain['mp3gain']['globalgain_track_max'] = intval($mp3gain_globalgain_max);
+					} else {
+						$info['warning'][] = 'MP3gainMinMax value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"';
+					}
 					break;
 
 				case 'mp3gain_album_minmax':
-					list($mp3gain_globalgain_album_min, $mp3gain_globalgain_album_max) = explode(',', $thisfile_ape_items_current['data'][0]);
-					$thisfile_replaygain['mp3gain']['globalgain_album_min'] = intval($mp3gain_globalgain_album_min);
-					$thisfile_replaygain['mp3gain']['globalgain_album_max'] = intval($mp3gain_globalgain_album_max);
+					if (preg_match('#^[0-9]{3},[0-9]{3}$#', $thisfile_ape_items_current['data'][0])) {
+						list($mp3gain_globalgain_album_min, $mp3gain_globalgain_album_max) = explode(',', $thisfile_ape_items_current['data'][0]);
+						$thisfile_replaygain['mp3gain']['globalgain_album_min'] = intval($mp3gain_globalgain_album_min);
+						$thisfile_replaygain['mp3gain']['globalgain_album_max'] = intval($mp3gain_globalgain_album_max);
+					} else {
+						$info['warning'][] = 'MP3gainAlbumMinMax value in APEtag appears invalid: "'.$thisfile_ape_items_current['data'][0].'"';
+					}
 					break;
 
 				case 'tracknumber':
@@ -222,16 +252,24 @@ class getid3_apetag extends getid3_handler
 				case 'cover art (recording)':
 				case 'cover art (studio)':
 					// list of possible cover arts from http://taglib-sharp.sourcearchive.com/documentation/2.0.3.0-2/Ape_2Tag_8cs-source.html
+					if (is_array($thisfile_ape_items_current['data'])) {
+						$info['warning'][] = 'APEtag "'.$item_key.'" should be flagged as Binary data, but was incorrectly flagged as UTF-8';
+						$thisfile_ape_items_current['data'] = implode("\x00", $thisfile_ape_items_current['data']);
+					}
 					list($thisfile_ape_items_current['filename'], $thisfile_ape_items_current['data']) = explode("\x00", $thisfile_ape_items_current['data'], 2);
 					$thisfile_ape_items_current['data_offset'] = $thisfile_ape_items_current['offset'] + strlen($thisfile_ape_items_current['filename']."\x00");
 					$thisfile_ape_items_current['data_length'] = strlen($thisfile_ape_items_current['data']);
 
-					$thisfile_ape_items_current['image_mime'] = '';
-					$imageinfo = array();
-					$imagechunkcheck = getid3_lib::GetDataImageSize($thisfile_ape_items_current['data'], $imageinfo);
-					$thisfile_ape_items_current['image_mime'] = image_type_to_mime_type($imagechunkcheck[2]);
-
 					do {
+						$thisfile_ape_items_current['image_mime'] = '';
+						$imageinfo = array();
+						$imagechunkcheck = getid3_lib::GetDataImageSize($thisfile_ape_items_current['data'], $imageinfo);
+						if (($imagechunkcheck === false) || !isset($imagechunkcheck[2])) {
+							$info['warning'][] = 'APEtag "'.$item_key.'" contains invalid image data';
+							break;
+						}
+						$thisfile_ape_items_current['image_mime'] = image_type_to_mime_type($imagechunkcheck[2]);
+
 						if ($this->inline_attachments === false) {
 							// skip entirely
 							unset($thisfile_ape_items_current['data']);
@@ -269,7 +307,14 @@ class getid3_apetag extends getid3_handler
 							if (!isset($info['ape']['comments']['picture'])) {
 								$info['ape']['comments']['picture'] = array();
 							}
-							$info['ape']['comments']['picture'][] = array('data'=>$thisfile_ape_items_current['data'], 'image_mime'=>$thisfile_ape_items_current['image_mime']);
+							$comments_picture_data = array();
+							foreach (array('data', 'image_mime', 'image_width', 'image_height', 'imagetype', 'picturetype', 'description', 'datalength') as $picture_key) {
+								if (isset($thisfile_ape_items_current[$picture_key])) {
+									$comments_picture_data[$picture_key] = $thisfile_ape_items_current[$picture_key];
+								}
+							}
+							$info['ape']['comments']['picture'][] = $comments_picture_data;
+							unset($comments_picture_data);
 						}
 					} while (false);
 					break;
@@ -317,7 +362,7 @@ class getid3_apetag extends getid3_handler
 	public function parseAPEtagFlags($rawflagint) {
 		// "Note: APE Tags 1.0 do not use any of the APE Tag flags.
 		// All are set to zero on creation and ignored on reading."
-		// http://www.uni-jena.de/~pfk/mpp/sv8/apetagflags.html
+		// http://wiki.hydrogenaud.io/index.php?title=Ape_Tags_Flags
 		$flags['header']            = (bool) ($rawflagint & 0x80000000);
 		$flags['footer']            = (bool) ($rawflagint & 0x40000000);
 		$flags['this_is_header']    = (bool) ($rawflagint & 0x20000000);

--- a/3rdparty/getID3/getid3/module.tag.id3v2.php
+++ b/3rdparty/getID3/getid3/module.tag.id3v2.php
@@ -442,10 +442,14 @@ class getid3_id3v2 extends getid3_handler
 		} // end footer
 
 		if (isset($thisfile_id3v2['comments']['genre'])) {
+			$genres = array();
 			foreach ($thisfile_id3v2['comments']['genre'] as $key => $value) {
-				unset($thisfile_id3v2['comments']['genre'][$key]);
-				$thisfile_id3v2['comments'] = getid3_lib::array_merge_noclobber($thisfile_id3v2['comments'], array('genre'=>$this->ParseID3v2GenreString($value)));
+				foreach ($this->ParseID3v2GenreString($value) as $genre) {
+					$genres[] = $genre;
+				}
 			}
+			$thisfile_id3v2['comments']['genre'] = array_unique($genres);
+			unset($key, $value, $genres, $genre);
 		}
 
 		if (isset($thisfile_id3v2['comments']['track'])) {
@@ -503,6 +507,16 @@ class getid3_id3v2 extends getid3_handler
 		if (strpos($genrestring, "\x00") === false) {
 			$genrestring = preg_replace('#\(([0-9]{1,3})\)#', '$1'."\x00", $genrestring);
 		}
+
+		// note: MusicBrainz Picard incorrectly stores plaintext genres separated by "/" when writing in ID3v2.3 mode, hack-fix here:
+		// replace / with NULL, then replace back the two ID3v1 genres that legitimately have "/" as part of the single genre name
+		$genrestring = str_replace('/', "\x00", $genrestring);
+		$genrestring = str_replace('Pop'."\x00".'Funk', 'Pop/Funk', $genrestring);
+		$genrestring = str_replace('Rock'."\x00".'Rock', 'Folk/Rock', $genrestring);
+
+		// some other taggers separate multiple genres with semicolon, e.g. "Heavy Metal;Thrash Metal;Metal"
+		$genrestring = str_replace(';', "\x00", $genrestring);
+
 		$genre_elements = explode("\x00", $genrestring);
 		foreach ($genre_elements as $element) {
 			$element = trim($element);
@@ -625,23 +639,25 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
-
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
 				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$frame_textencoding_terminator = "\x00";
 			}
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
 			$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-			if (ord($frame_description) === 0) {
+			if (in_array($frame_description, array("\x00", "\x00\x00", "\xFF\xFE", "\xFE\xFF"))) {
+				// if description only contains a BOM or terminator then make it blank
 				$frame_description = '';
 			}
 			$parsedFrame['encodingid']  = $frame_textencoding;
 			$parsedFrame['encoding']    = $this->TextEncodingNameLookup($frame_textencoding);
 
-			$parsedFrame['description'] = $frame_description;
-			$parsedFrame['data'] = substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)));
+			$parsedFrame['description'] = trim(getid3_lib::iconv_fallback($parsedFrame['encoding'], $info['id3v2']['encoding'], $frame_description));
+			$parsedFrame['data'] = substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator));
 			if (!empty($parsedFrame['framenameshort']) && !empty($parsedFrame['data'])) {
 				$commentkey = ($parsedFrame['description'] ? $parsedFrame['description'] : (isset($info['id3v2']['comments'][$parsedFrame['framenameshort']]) ? count($info['id3v2']['comments'][$parsedFrame['framenameshort']]) : 0));
 				if (!isset($info['id3v2']['comments'][$parsedFrame['framenameshort']]) || !array_key_exists($commentkey, $info['id3v2']['comments'][$parsedFrame['framenameshort']])) {
@@ -717,22 +733,24 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
 				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$frame_textencoding_terminator = "\x00";
 			}
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
 			$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-
-			if (ord($frame_description) === 0) {
+			if (in_array($frame_description, array("\x00", "\x00\x00", "\xFF\xFE", "\xFE\xFF"))) {
+				// if description only contains a BOM or terminator then make it blank
 				$frame_description = '';
 			}
-			$parsedFrame['data'] = substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)));
+			$parsedFrame['data'] = substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator));
 
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding));
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
 			if ($frame_terminatorpos) {
@@ -956,25 +974,27 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
 				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$frame_textencoding_terminator = "\x00";
 			}
 			$frame_language = substr($parsedFrame['data'], $frame_offset, 3);
 			$frame_offset += 3;
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
 			$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-			if (ord($frame_description) === 0) {
+			if (in_array($frame_description, array("\x00", "\x00\x00", "\xFF\xFE", "\xFE\xFF"))) {
+				// if description only contains a BOM or terminator then make it blank
 				$frame_description = '';
 			}
-			$parsedFrame['data'] = substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)));
+			$parsedFrame['data'] = substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator));
 
 			$parsedFrame['encodingid']   = $frame_textencoding;
 			$parsedFrame['encoding']     = $this->TextEncodingNameLookup($frame_textencoding);
 
-			$parsedFrame['data']         = $parsedFrame['data'];
 			$parsedFrame['language']     = $frame_language;
 			$parsedFrame['languagename'] = $this->LanguageLookup($frame_language, false);
 			$parsedFrame['description']  = $frame_description;
@@ -1002,8 +1022,10 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
 				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$frame_textencoding_terminator = "\x00";
 			}
 			$frame_language = substr($parsedFrame['data'], $frame_offset, 3);
 			$frame_offset += 3;
@@ -1020,16 +1042,16 @@ class getid3_id3v2 extends getid3_handler
 			$frame_remainingdata = substr($parsedFrame['data'], $frame_offset);
 			while (strlen($frame_remainingdata)) {
 				$frame_offset = 0;
-				$frame_terminatorpos = strpos($frame_remainingdata, $this->TextEncodingTerminatorLookup($frame_textencoding));
+				$frame_terminatorpos = strpos($frame_remainingdata, $frame_textencoding_terminator);
 				if ($frame_terminatorpos === false) {
 					$frame_remainingdata = '';
 				} else {
-					if (ord(substr($frame_remainingdata, $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+					if (ord(substr($frame_remainingdata, $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 						$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 					}
 					$parsedFrame['lyrics'][$timestampindex]['data'] = substr($frame_remainingdata, $frame_offset, $frame_terminatorpos - $frame_offset);
 
-					$frame_remainingdata = substr($frame_remainingdata, $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)));
+					$frame_remainingdata = substr($frame_remainingdata, $frame_terminatorpos + strlen($frame_textencoding_terminator));
 					if (($timestampindex == 0) && (ord($frame_remainingdata{0}) != 0)) {
 						// timestamp probably omitted for first data item
 					} else {
@@ -1060,20 +1082,23 @@ class getid3_id3v2 extends getid3_handler
 
 				$frame_offset = 0;
 				$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+				$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 				if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
 					$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+					$frame_textencoding_terminator = "\x00";
 				}
 				$frame_language = substr($parsedFrame['data'], $frame_offset, 3);
 				$frame_offset += 3;
-				$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-				if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+				$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+				if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 					$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 				}
 				$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-				if (ord($frame_description) === 0) {
+				if (in_array($frame_description, array("\x00", "\x00\x00", "\xFF\xFE", "\xFE\xFF"))) {
+					// if description only contains a BOM or terminator then make it blank
 					$frame_description = '';
 				}
-				$frame_text = (string) substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)));
+				$frame_text = (string) substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator));
 
 				$parsedFrame['encodingid']   = $frame_textencoding;
 				$parsedFrame['encoding']     = $this->TextEncodingNameLookup($frame_textencoding);
@@ -1330,8 +1355,10 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
 				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$frame_textencoding_terminator = "\x00";
 			}
 
 			if ($id3v2_majorversion == 2 && strlen($parsedFrame['data']) > $frame_offset) {
@@ -1367,12 +1394,13 @@ class getid3_id3v2 extends getid3_handler
 			if ($frame_offset >= $parsedFrame['datalength']) {
 				$info['warning'][] = 'data portion of APIC frame is missing at offset '.($parsedFrame['dataoffset'] + 8 + $frame_offset);
 			} else {
-				$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-				if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+				$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+				if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 					$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 				}
 				$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-				if (ord($frame_description) === 0) {
+				if (in_array($frame_description, array("\x00", "\x00\x00", "\xFF\xFE", "\xFE\xFF"))) {
+					// if description only contains a BOM or terminator then make it blank
 					$frame_description = '';
 				}
 				$parsedFrame['encodingid']       = $frame_textencoding;
@@ -1386,19 +1414,20 @@ class getid3_id3v2 extends getid3_handler
 				$parsedFrame['picturetypeid']    = $frame_picturetype;
 				$parsedFrame['picturetype']      = $this->APICPictureTypeLookup($frame_picturetype);
 				$parsedFrame['description']      = $frame_description;
-				$parsedFrame['data']             = substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)));
+				$parsedFrame['data']             = substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator));
 				$parsedFrame['datalength']       = strlen($parsedFrame['data']);
 
 				$parsedFrame['image_mime'] = '';
 				$imageinfo = array();
-				$imagechunkcheck = getid3_lib::GetDataImageSize($parsedFrame['data'], $imageinfo);
-				if (($imagechunkcheck[2] >= 1) && ($imagechunkcheck[2] <= 3)) {
-					$parsedFrame['image_mime']       = 'image/'.getid3_lib::ImageTypesLookup($imagechunkcheck[2]);
-					if ($imagechunkcheck[0]) {
-						$parsedFrame['image_width']  = $imagechunkcheck[0];
-					}
-					if ($imagechunkcheck[1]) {
-						$parsedFrame['image_height'] = $imagechunkcheck[1];
+				if ($imagechunkcheck = getid3_lib::GetDataImageSize($parsedFrame['data'], $imageinfo)) {
+					if (($imagechunkcheck[2] >= 1) && ($imagechunkcheck[2] <= 3)) {
+						$parsedFrame['image_mime']       = 'image/'.getid3_lib::ImageTypesLookup($imagechunkcheck[2]);
+						if ($imagechunkcheck[0]) {
+							$parsedFrame['image_width']  = $imagechunkcheck[0];
+						}
+						if ($imagechunkcheck[1]) {
+							$parsedFrame['image_height'] = $imagechunkcheck[1];
+						}
 					}
 				}
 
@@ -1443,7 +1472,14 @@ class getid3_id3v2 extends getid3_handler
 							if (!isset($info['id3v2']['comments']['picture'])) {
 								$info['id3v2']['comments']['picture'] = array();
 							}
-							$info['id3v2']['comments']['picture'][] = array('data'=>$parsedFrame['data'], 'image_mime'=>$parsedFrame['image_mime']);
+							$comments_picture_data = array();
+							foreach (array('data', 'image_mime', 'image_width', 'image_height', 'imagetype', 'picturetype', 'description', 'datalength') as $picture_key) {
+								if (isset($parsedFrame[$picture_key])) {
+									$comments_picture_data[$picture_key] = $parsedFrame[$picture_key];
+								}
+							}
+							$info['id3v2']['comments']['picture'][] = $comments_picture_data;
+							unset($comments_picture_data);
 						}
 					}
 				} while (false);
@@ -1462,8 +1498,10 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
 				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$frame_textencoding_terminator = "\x00";
 			}
 			$frame_terminatorpos = strpos($parsedFrame['data'], "\x00", $frame_offset);
 			$frame_mimetype = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
@@ -1472,25 +1510,26 @@ class getid3_id3v2 extends getid3_handler
 			}
 			$frame_offset = $frame_terminatorpos + strlen("\x00");
 
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
 			$frame_filename = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
 			if (ord($frame_filename) === 0) {
 				$frame_filename = '';
 			}
-			$frame_offset = $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding));
+			$frame_offset = $frame_terminatorpos + strlen($frame_textencoding_terminator);
 
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
 			$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-			if (ord($frame_description) === 0) {
+			if (in_array($frame_description, array("\x00", "\x00\x00", "\xFF\xFE", "\xFE\xFF"))) {
+				// if description only contains a BOM or terminator then make it blank
 				$frame_description = '';
 			}
-			$frame_offset = $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding));
+			$frame_offset = $frame_terminatorpos + strlen($frame_textencoding_terminator);
 
 			$parsedFrame['objectdata']  = (string) substr($parsedFrame['data'], $frame_offset);
 			$parsedFrame['encodingid']  = $frame_textencoding;
@@ -1569,7 +1608,8 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_terminatorpos = strpos($parsedFrame['data'], "\x00", $frame_offset);
 			$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-			if (ord($frame_description) === 0) {
+			if (in_array($frame_description, array("\x00", "\x00\x00", "\xFF\xFE", "\xFE\xFF"))) {
+				// if description only contains a BOM or terminator then make it blank
 				$frame_description = '';
 			}
 			$frame_offset = $frame_terminatorpos + strlen("\x00");
@@ -1594,7 +1634,7 @@ class getid3_id3v2 extends getid3_handler
 			$frame_terminatorpos = strpos($parsedFrame['data'], "\x00", $frame_offset);
 			$frame_ownerid = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
 			if (ord($frame_ownerid) === 0) {
-				$frame_ownerid == '';
+				$frame_ownerid = '';
 			}
 			$frame_offset = $frame_terminatorpos + strlen("\x00");
 			$parsedFrame['ownerid'] = $frame_ownerid;
@@ -1607,7 +1647,7 @@ class getid3_id3v2 extends getid3_handler
 
 
 		} elseif ((($id3v2_majorversion >= 3) && ($parsedFrame['frame_name'] == 'LINK')) || // 4.20  LINK Linked information
-				(($id3v2_majorversion == 2) && ($parsedFrame['frame_name'] == 'LNK'))) {     // 4.22  LNK  Linked information
+				(($id3v2_majorversion == 2) && ($parsedFrame['frame_name'] == 'LNK'))) {    // 4.22  LNK  Linked information
 			//   There may be more than one 'LINK' frame in a tag,
 			//   but only one with the same contents
 			// <Header for 'Linked information', ID: 'LINK'>
@@ -1635,7 +1675,7 @@ class getid3_id3v2 extends getid3_handler
 
 			$parsedFrame['additionaldata'] = (string) substr($parsedFrame['data'], $frame_offset);
 			if (!empty($parsedFrame['framenameshort']) && $parsedFrame['url']) {
-				$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = utf8_encode($parsedFrame['url']);
+				$info['id3v2']['comments'][$parsedFrame['framenameshort']][] = getid3_lib::iconv_fallback_iso88591_utf8($parsedFrame['url']);
 			}
 			unset($parsedFrame['data']);
 
@@ -1729,8 +1769,10 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_offset = 0;
 			$frame_textencoding = ord(substr($parsedFrame['data'], $frame_offset++, 1));
+			$frame_textencoding_terminator = $this->TextEncodingTerminatorLookup($frame_textencoding);
 			if ((($id3v2_majorversion <= 3) && ($frame_textencoding > 1)) || (($id3v2_majorversion == 4) && ($frame_textencoding > 3))) {
 				$info['warning'][] = 'Invalid text encoding byte ('.$frame_textencoding.') in frame "'.$parsedFrame['frame_name'].'" - defaulting to ISO-8859-1 encoding';
+				$frame_textencoding_terminator = "\x00";
 			}
 
 			$frame_terminatorpos = strpos($parsedFrame['data'], "\x00", $frame_offset);
@@ -1752,25 +1794,26 @@ class getid3_id3v2 extends getid3_handler
 
 			$frame_receivedasid = ord(substr($parsedFrame['data'], $frame_offset++, 1));
 
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
 			$frame_sellername = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
 			if (ord($frame_sellername) === 0) {
 				$frame_sellername = '';
 			}
-			$frame_offset = $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding));
+			$frame_offset = $frame_terminatorpos + strlen($frame_textencoding_terminator);
 
-			$frame_terminatorpos = strpos($parsedFrame['data'], $this->TextEncodingTerminatorLookup($frame_textencoding), $frame_offset);
-			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding)), 1)) === 0) {
+			$frame_terminatorpos = strpos($parsedFrame['data'], $frame_textencoding_terminator, $frame_offset);
+			if (ord(substr($parsedFrame['data'], $frame_terminatorpos + strlen($frame_textencoding_terminator), 1)) === 0) {
 				$frame_terminatorpos++; // strpos() fooled because 2nd byte of Unicode chars are often 0x00
 			}
 			$frame_description = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
-			if (ord($frame_description) === 0) {
+			if (in_array($frame_description, array("\x00", "\x00\x00", "\xFF\xFE", "\xFE\xFF"))) {
+				// if description only contains a BOM or terminator then make it blank
 				$frame_description = '';
 			}
-			$frame_offset = $frame_terminatorpos + strlen($this->TextEncodingTerminatorLookup($frame_textencoding));
+			$frame_offset = $frame_terminatorpos + strlen($frame_textencoding_terminator);
 
 			$frame_terminatorpos = strpos($parsedFrame['data'], "\x00", $frame_offset);
 			$frame_mimetype = substr($parsedFrame['data'], $frame_offset, $frame_terminatorpos - $frame_offset);
@@ -1943,6 +1986,186 @@ class getid3_id3v2 extends getid3_handler
 			$info['replay_gain']['album']['adjustment'] = $parsedFrame['album']['adjustment'];
 
 			unset($parsedFrame['data']);
+
+		} elseif (($id3v2_majorversion >= 3) && ($parsedFrame['frame_name'] == 'CHAP')) { // CHAP Chapters frame (ID3v2.3+ only)
+			// http://id3.org/id3v2-chapters-1.0
+			// <ID3v2.3 or ID3v2.4 frame header, ID: "CHAP">           (10 bytes)
+			// Element ID      <text string> $00
+			// Start time      $xx xx xx xx
+			// End time        $xx xx xx xx
+            // Start offset    $xx xx xx xx
+            // End offset      $xx xx xx xx
+            // <Optional embedded sub-frames>
+
+			$frame_offset = 0;
+			@list($parsedFrame['element_id']) = explode("\x00", $parsedFrame['data'], 2);
+			$frame_offset += strlen($parsedFrame['element_id']."\x00");
+			$parsedFrame['time_begin'] = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 4));
+			$frame_offset += 4;
+			$parsedFrame['time_end']   = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 4));
+			$frame_offset += 4;
+			if (substr($parsedFrame['data'], $frame_offset, 4) != "\xFF\xFF\xFF\xFF") {
+				// "If these bytes are all set to 0xFF then the value should be ignored and the start time value should be utilized."
+				$parsedFrame['offset_begin'] = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 4));
+			}
+			$frame_offset += 4;
+			if (substr($parsedFrame['data'], $frame_offset, 4) != "\xFF\xFF\xFF\xFF") {
+				// "If these bytes are all set to 0xFF then the value should be ignored and the start time value should be utilized."
+				$parsedFrame['offset_end']   = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 4));
+			}
+			$frame_offset += 4;
+
+			if ($frame_offset < strlen($parsedFrame['data'])) {
+				$parsedFrame['subframes'] = array();
+				while ($frame_offset < strlen($parsedFrame['data'])) {
+					// <Optional embedded sub-frames>
+					$subframe = array();
+					$subframe['name']      =                           substr($parsedFrame['data'], $frame_offset, 4);
+					$frame_offset += 4;
+					$subframe['size']      = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 4));
+					$frame_offset += 4;
+					$subframe['flags_raw'] = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 2));
+					$frame_offset += 2;
+					if ($subframe['size'] > (strlen($parsedFrame['data']) - $frame_offset)) {
+						$info['warning'][] = 'CHAP subframe "'.$subframe['name'].'" at frame offset '.$frame_offset.' claims to be "'.$subframe['size'].'" bytes, which is more than the available data ('.(strlen($parsedFrame['data']) - $frame_offset).' bytes)';
+						break;
+					}
+					$subframe_rawdata = substr($parsedFrame['data'], $frame_offset, $subframe['size']);
+					$frame_offset += $subframe['size'];
+
+					$subframe['encodingid'] = ord(substr($subframe_rawdata, 0, 1));
+					$subframe['text']       =     substr($subframe_rawdata, 1);
+					$subframe['encoding']   = $this->TextEncodingNameLookup($subframe['encodingid']);
+					$encoding_converted_text = trim(getid3_lib::iconv_fallback($subframe['encoding'], $info['encoding'], $subframe['text']));;
+					switch (substr($encoding_converted_text, 0, 2)) {
+						case "\xFF\xFE":
+						case "\xFE\xFF":
+							switch (strtoupper($info['id3v2']['encoding'])) {
+								case 'ISO-8859-1':
+								case 'UTF-8':
+									$encoding_converted_text = substr($encoding_converted_text, 2);
+									// remove unwanted byte-order-marks
+									break;
+								default:
+									// ignore
+									break;
+							}
+							break;
+						default:
+							// do not remove BOM
+							break;
+					}
+
+					if (($subframe['name'] == 'TIT2') || ($subframe['name'] == 'TIT3')) {
+						if ($subframe['name'] == 'TIT2') {
+							$parsedFrame['chapter_name']        = $encoding_converted_text;
+						} elseif ($subframe['name'] == 'TIT3') {
+							$parsedFrame['chapter_description'] = $encoding_converted_text;
+						}
+						$parsedFrame['subframes'][] = $subframe;
+					} else {
+						$info['warning'][] = 'ID3v2.CHAP subframe "'.$subframe['name'].'" not handled (only TIT2 and TIT3)';
+					}
+				}
+				unset($subframe_rawdata, $subframe, $encoding_converted_text);
+			}
+
+			$id3v2_chapter_entry = array();
+			foreach (array('id', 'time_begin', 'time_end', 'offset_begin', 'offset_end', 'chapter_name', 'chapter_description') as $id3v2_chapter_key) {
+				if (isset($parsedFrame[$id3v2_chapter_key])) {
+					$id3v2_chapter_entry[$id3v2_chapter_key] = $parsedFrame[$id3v2_chapter_key];
+				}
+			}
+			if (!isset($info['id3v2']['chapters'])) {
+				$info['id3v2']['chapters'] = array();
+			}
+			$info['id3v2']['chapters'][] = $id3v2_chapter_entry;
+			unset($id3v2_chapter_entry, $id3v2_chapter_key);
+
+
+		} elseif (($id3v2_majorversion >= 3) && ($parsedFrame['frame_name'] == 'CTOC')) { // CTOC Chapters Table Of Contents frame (ID3v2.3+ only)
+			// http://id3.org/id3v2-chapters-1.0
+			// <ID3v2.3 or ID3v2.4 frame header, ID: "CTOC">           (10 bytes)
+			// Element ID      <text string> $00
+			// CTOC flags        %xx
+			// Entry count       $xx
+			// Child Element ID  <string>$00   /* zero or more child CHAP or CTOC entries */
+            // <Optional embedded sub-frames>
+
+			$frame_offset = 0;
+			@list($parsedFrame['element_id']) = explode("\x00", $parsedFrame['data'], 2);
+			$frame_offset += strlen($parsedFrame['element_id']."\x00");
+			$ctoc_flags_raw = ord(substr($parsedFrame['data'], $frame_offset, 1));
+			$frame_offset += 1;
+			$parsedFrame['entry_count'] = ord(substr($parsedFrame['data'], $frame_offset, 1));
+			$frame_offset += 1;
+
+			$terminator_position = null;
+			for ($i = 0; $i < $parsedFrame['entry_count']; $i++) {
+				$terminator_position = strpos($parsedFrame['data'], "\x00", $frame_offset);
+				$parsedFrame['child_element_ids'][$i] = substr($parsedFrame['data'], $frame_offset, $terminator_position - $frame_offset);
+				$frame_offset = $terminator_position + 1;
+			}
+
+			$parsedFrame['ctoc_flags']['ordered']   = (bool) ($ctoc_flags_raw & 0x01);
+			$parsedFrame['ctoc_flags']['top_level'] = (bool) ($ctoc_flags_raw & 0x03);
+
+			unset($ctoc_flags_raw, $terminator_position);
+
+			if ($frame_offset < strlen($parsedFrame['data'])) {
+				$parsedFrame['subframes'] = array();
+				while ($frame_offset < strlen($parsedFrame['data'])) {
+					// <Optional embedded sub-frames>
+					$subframe = array();
+					$subframe['name']      =                           substr($parsedFrame['data'], $frame_offset, 4);
+					$frame_offset += 4;
+					$subframe['size']      = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 4));
+					$frame_offset += 4;
+					$subframe['flags_raw'] = getid3_lib::BigEndian2Int(substr($parsedFrame['data'], $frame_offset, 2));
+					$frame_offset += 2;
+					if ($subframe['size'] > (strlen($parsedFrame['data']) - $frame_offset)) {
+						$info['warning'][] = 'CTOS subframe "'.$subframe['name'].'" at frame offset '.$frame_offset.' claims to be "'.$subframe['size'].'" bytes, which is more than the available data ('.(strlen($parsedFrame['data']) - $frame_offset).' bytes)';
+						break;
+					}
+					$subframe_rawdata = substr($parsedFrame['data'], $frame_offset, $subframe['size']);
+					$frame_offset += $subframe['size'];
+
+					$subframe['encodingid'] = ord(substr($subframe_rawdata, 0, 1));
+					$subframe['text']       =     substr($subframe_rawdata, 1);
+					$subframe['encoding']   = $this->TextEncodingNameLookup($subframe['encodingid']);
+					$encoding_converted_text = trim(getid3_lib::iconv_fallback($subframe['encoding'], $info['encoding'], $subframe['text']));;
+					switch (substr($encoding_converted_text, 0, 2)) {
+						case "\xFF\xFE":
+						case "\xFE\xFF":
+							switch (strtoupper($info['id3v2']['encoding'])) {
+								case 'ISO-8859-1':
+								case 'UTF-8':
+									$encoding_converted_text = substr($encoding_converted_text, 2);
+									// remove unwanted byte-order-marks
+									break;
+								default:
+									// ignore
+									break;
+							}
+							break;
+						default:
+							// do not remove BOM
+							break;
+					}
+
+					if (($subframe['name'] == 'TIT2') || ($subframe['name'] == 'TIT3')) {
+						if ($subframe['name'] == 'TIT2') {
+							$parsedFrame['toc_name']        = $encoding_converted_text;
+						} elseif ($subframe['name'] == 'TIT3') {
+							$parsedFrame['toc_description'] = $encoding_converted_text;
+						}
+						$parsedFrame['subframes'][] = $subframe;
+					} else {
+						$info['warning'][] = 'ID3v2.CTOC subframe "'.$subframe['name'].'" not handled (only TIT2 and TIT3)';
+					}
+				}
+				unset($subframe_rawdata, $subframe, $encoding_converted_text);
+			}
 
 		}
 
@@ -3344,7 +3567,7 @@ class getid3_id3v2 extends getid3_handler
 			3   => "\x00",     // $03  UTF-8 encoded Unicode. Terminated with $00.
 			255 => "\x00\x00"
 		);
-		return (isset($TextEncodingTerminatorLookup[$encoding]) ? $TextEncodingTerminatorLookup[$encoding] : '');
+		return (isset($TextEncodingTerminatorLookup[$encoding]) ? $TextEncodingTerminatorLookup[$encoding] : "\x00");
 	}
 
 	public static function TextEncodingNameLookup($encoding) {

--- a/3rdparty/getID3/getid3/module.tag.lyrics3.php
+++ b/3rdparty/getID3/getid3/module.tag.lyrics3.php
@@ -101,20 +101,24 @@ class getid3_lyrics3 extends getid3_handler
 			$this->getLyrics3Data($lyrics3offset, $lyrics3version, $lyrics3size);
 
 			if (!isset($info['ape'])) {
-				$GETID3_ERRORARRAY = &$info['warning'];
-				getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.apetag.php', __FILE__, true);
-				$getid3_temp = new getID3();
-				$getid3_temp->openfile($this->getid3->filename);
-				$getid3_apetag = new getid3_apetag($getid3_temp);
-				$getid3_apetag->overrideendoffset = $info['lyrics3']['tag_offset_start'];
-				$getid3_apetag->Analyze();
-				if (!empty($getid3_temp->info['ape'])) {
-					$info['ape'] = $getid3_temp->info['ape'];
+				if (isset($info['lyrics3']['tag_offset_start'])) {
+					$GETID3_ERRORARRAY = &$info['warning'];
+					getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.apetag.php', __FILE__, true);
+					$getid3_temp = new getID3();
+					$getid3_temp->openfile($this->getid3->filename);
+					$getid3_apetag = new getid3_apetag($getid3_temp);
+					$getid3_apetag->overrideendoffset = $info['lyrics3']['tag_offset_start'];
+					$getid3_apetag->Analyze();
+					if (!empty($getid3_temp->info['ape'])) {
+						$info['ape'] = $getid3_temp->info['ape'];
+					}
+					if (!empty($getid3_temp->info['replay_gain'])) {
+						$info['replay_gain'] = $getid3_temp->info['replay_gain'];
+					}
+					unset($getid3_temp, $getid3_apetag);
+				} else {
+					$info['warning'][] = 'Lyrics3 and APE tags appear to have become entangled (most likely due to updating the APE tags with a non-Lyrics3-aware tagger)';
 				}
-				if (!empty($getid3_temp->info['replay_gain'])) {
-					$info['replay_gain'] = $getid3_temp->info['replay_gain'];
-				}
-				unset($getid3_temp, $getid3_apetag);
 			}
 
 		}

--- a/3rdparty/getID3/getid3/module.tag.xmp.php
+++ b/3rdparty/getID3/getid3/module.tag.xmp.php
@@ -399,7 +399,7 @@ class Image_XMP
 	*
 	* @param string - Name of the image file to access and extract XMP information from.
 	*/
-	public function Image_XMP($sFilename)
+	public function __construct($sFilename)
 	{
 		$this->_sFilename = $sFilename;
 

--- a/3rdparty/getID3/getid3/write.apetag.php
+++ b/3rdparty/getID3/getid3/write.apetag.php
@@ -26,7 +26,7 @@ class getid3_write_apetag
 	public $warnings                   = array(); // any non-critical errors will be stored here
 	public $errors                     = array(); // any critical errors will be stored here
 
-	public function getid3_write_apetag() {
+	public function __construct() {
 		return true;
 	}
 

--- a/3rdparty/getID3/getid3/write.id3v1.php
+++ b/3rdparty/getID3/getid3/write.id3v1.php
@@ -24,7 +24,7 @@ class getid3_write_id3v1
 	public $warnings = array(); // any non-critical errors will be stored here
 	public $errors   = array(); // any critical errors will be stored here
 
-	public function getid3_write_id3v1() {
+	public function __construct() {
 		return true;
 	}
 

--- a/3rdparty/getID3/getid3/write.id3v2.php
+++ b/3rdparty/getID3/getid3/write.id3v2.php
@@ -30,7 +30,7 @@ class getid3_write_id3v2
 	public $warnings                    = array();  // any non-critical errors will be stored here
 	public $errors                      = array();  // any critical errors will be stored here
 
-	public function getid3_write_id3v2() {
+	public function __construct() {
 		return true;
 	}
 
@@ -1543,6 +1543,9 @@ class getid3_write_id3v2
 						unset($frame_flags);
 						$frame_data = false;
 						if ($this->ID3v2FrameIsAllowed($frame_name, $source_data_array)) {
+							if(array_key_exists('description', $source_data_array) && array_key_exists('encodingid', $source_data_array) && array_key_exists('encoding', $this->tag_data)) {
+								$source_data_array['description'] = getid3_lib::iconv_fallback($this->tag_data['encoding'], $source_data_array['encoding'], $source_data_array['description']);
+							}
 							if ($frame_data = $this->GenerateID3v2FrameData($frame_name, $source_data_array)) {
 								$FrameUnsynchronisation = false;
 								if ($this->majorversion >= 4) {
@@ -1756,10 +1759,15 @@ class getid3_write_id3v2
 	}
 
 	public function ID3v2IsValidTextEncoding($textencodingbyte) {
+		// 0 = ISO-8859-1
+		// 1 = UTF-16 with BOM
+		// 2 = UTF-16BE without BOM
+		// 3 = UTF-8
 		static $ID3v2IsValidTextEncoding_cache = array(
-			2 => array(true, true),
-			3 => array(true, true),
-			4 => array(true, true, true, true));
+			2 => array(true, true),              // ID3v2.2 - allow 0=ISO-8859-1, 1=UTF-16
+			3 => array(true, true),              // ID3v2.3 - allow 0=ISO-8859-1, 1=UTF-16
+			4 => array(true, true, true, true),  // ID3v2.4 - allow 0=ISO-8859-1, 1=UTF-16, 2=UTF-16BE, 3=UTF-8
+		);
 		return isset($ID3v2IsValidTextEncoding_cache[$this->majorversion][$textencodingbyte]);
 	}
 
@@ -1903,6 +1911,7 @@ class getid3_write_id3v2
 			$ID3v2ShortFrameNameLookup[2]['comment']                                          = 'COM';
 			$ID3v2ShortFrameNameLookup[2]['album']                                            = 'TAL';
 			$ID3v2ShortFrameNameLookup[2]['beats_per_minute']                                 = 'TBP';
+			$ID3v2ShortFrameNameLookup[2]['bpm']                                              = 'TBP';
 			$ID3v2ShortFrameNameLookup[2]['composer']                                         = 'TCM';
 			$ID3v2ShortFrameNameLookup[2]['genre']                                            = 'TCO';
 			$ID3v2ShortFrameNameLookup[2]['itunescompilation']                                = 'TCP';
@@ -1921,6 +1930,7 @@ class getid3_write_id3v2
 			$ID3v2ShortFrameNameLookup[2]['publisher']                                        = 'TPB';
 			$ID3v2ShortFrameNameLookup[2]['isrc']                                             = 'TRC';
 			$ID3v2ShortFrameNameLookup[2]['tracknumber']                                      = 'TRK';
+			$ID3v2ShortFrameNameLookup[2]['track_number']                                     = 'TRK';
 			$ID3v2ShortFrameNameLookup[2]['size']                                             = 'TSI';
 			$ID3v2ShortFrameNameLookup[2]['encoder_settings']                                 = 'TSS';
 			$ID3v2ShortFrameNameLookup[2]['description']                                      = 'TT1';
@@ -1941,6 +1951,7 @@ class getid3_write_id3v2
 			// The following are common to ID3v2.3 and ID3v2.4
 			$ID3v2ShortFrameNameLookup[3]['audio_encryption']                                 = 'AENC';
 			$ID3v2ShortFrameNameLookup[3]['attached_picture']                                 = 'APIC';
+			$ID3v2ShortFrameNameLookup[3]['picture']                                          = 'APIC';
 			$ID3v2ShortFrameNameLookup[3]['comment']                                          = 'COMM';
 			$ID3v2ShortFrameNameLookup[3]['commercial']                                       = 'COMR';
 			$ID3v2ShortFrameNameLookup[3]['encryption_method_registration']                   = 'ENCR';
@@ -1961,6 +1972,7 @@ class getid3_write_id3v2
 			$ID3v2ShortFrameNameLookup[3]['synchronised_tempo_codes']                         = 'SYTC';
 			$ID3v2ShortFrameNameLookup[3]['album']                                            = 'TALB';
 			$ID3v2ShortFrameNameLookup[3]['beats_per_minute']                                 = 'TBPM';
+			$ID3v2ShortFrameNameLookup[3]['bpm']                                              = 'TBPM';
 			$ID3v2ShortFrameNameLookup[3]['itunescompilation']                                = 'TCMP';
 			$ID3v2ShortFrameNameLookup[3]['composer']                                         = 'TCOM';
 			$ID3v2ShortFrameNameLookup[3]['genre']                                            = 'TCON';
@@ -1988,6 +2000,7 @@ class getid3_write_id3v2
 			$ID3v2ShortFrameNameLookup[3]['part_of_a_set']                                    = 'TPOS';
 			$ID3v2ShortFrameNameLookup[3]['publisher']                                        = 'TPUB';
 			$ID3v2ShortFrameNameLookup[3]['tracknumber']                                      = 'TRCK';
+			$ID3v2ShortFrameNameLookup[3]['track_number']                                     = 'TRCK';
 			$ID3v2ShortFrameNameLookup[3]['internet_radio_station_name']                      = 'TRSN';
 			$ID3v2ShortFrameNameLookup[3]['internet_radio_station_owner']                     = 'TRSO';
 			$ID3v2ShortFrameNameLookup[3]['isrc']                                             = 'TSRC';

--- a/3rdparty/getID3/getid3/write.lyrics3.php
+++ b/3rdparty/getID3/getid3/write.lyrics3.php
@@ -23,7 +23,7 @@ class getid3_write_lyrics3
 	public $warnings        = array(); // any non-critical errors will be stored here
 	public $errors          = array(); // any critical errors will be stored here
 
-	public function getid3_write_lyrics3() {
+	public function __construct() {
 		return true;
 	}
 

--- a/3rdparty/getID3/getid3/write.metaflac.php
+++ b/3rdparty/getID3/getid3/write.metaflac.php
@@ -23,7 +23,7 @@ class getid3_write_metaflac
 	public $warnings = array(); // any non-critical errors will be stored here
 	public $errors   = array(); // any critical errors will be stored here
 
-	public function getid3_write_metaflac() {
+	public function __construct() {
 		return true;
 	}
 

--- a/3rdparty/getID3/getid3/write.php
+++ b/3rdparty/getID3/getid3/write.php
@@ -64,7 +64,7 @@ class getid3_writetags
 	// private
 	private $ThisFileInfo; // analysis of file before writing
 
-	public function getid3_writetags() {
+	public function __construct() {
 		return true;
 	}
 

--- a/3rdparty/getID3/getid3/write.real.php
+++ b/3rdparty/getID3/getid3/write.real.php
@@ -23,7 +23,7 @@ class getid3_write_real
 	public $errors            = array(); // any critical errors will be stored here
 	public $paddedlength      = 512;     // minimum length of CONT tag in bytes
 
-	public function getid3_write_real() {
+	public function __construct() {
 		return true;
 	}
 

--- a/3rdparty/getID3/getid3/write.vorbiscomment.php
+++ b/3rdparty/getID3/getid3/write.vorbiscomment.php
@@ -23,7 +23,7 @@ class getid3_write_vorbiscomment
 	public $warnings = array(); // any non-critical errors will be stored here
 	public $errors   = array(); // any critical errors will be stored here
 
-	public function getid3_write_vorbiscomment() {
+	public function __construct() {
 		return true;
 	}
 

--- a/3rdparty/getID3/readme.txt
+++ b/3rdparty/getID3/readme.txt
@@ -77,7 +77,7 @@ Reads & parses (to varying degrees):
  ¤ audio-lossy:
   * MP3/MP2/MP1
   * MPC / Musepack
-  * Ogg (Vorbis, OggFLAC, Speex)
+  * Ogg (Vorbis, OggFLAC, Speex, Opus)
   * AAC / MP4
   * AC3
   * DTS
@@ -187,7 +187,7 @@ if ($fp_remote = fopen($remotefilename, 'rb')) {
 		// Initialize getID3 engine
 		$getID3 = new getID3;
 
-		$ThisFileInfo = $getID3->analyze($filename);
+		$ThisFileInfo = $getID3->analyze($localtempfilename);
 
         // Delete temporary file
         unlink($localtempfilename);
@@ -195,6 +195,11 @@ if ($fp_remote = fopen($remotefilename, 'rb')) {
     fclose($fp_remote);
 }
 
+Note: since v1.9.9-20150212 it is possible a second and third parameter
+to $getID3->analyze(), for original filesize and original filename
+respectively. This permits you to download only a portion of a large remote
+file but get accurate playtime estimates, assuming the format only requires
+the beginning of the file for correct format analysis.
 
 See /demos/demo.write.php for how to write tags.
 
@@ -432,6 +437,13 @@ Known Bugs/Issues in other programs
 -----------------------------------
 http://www.getid3.org/phpBB3/viewtopic.php?t=25
 
+* MusicBrainz Picard (at least up to v1.3.2) writes multiple
+  ID3v2.3 genres in non-standard forward-slash separated text
+  rather than parenthesis-numeric+refinement style per the ID3v2.3
+  specs. Tags written in ID3v2.4 mode are written correctly.
+  (detected and worked around by getID3())
+* PZ TagEditor v4.53.408 has been known to insert ID3v2.3 frames
+  into an existing ID3v2.2 tag which, of course, breaks things
 * Windows Media Player (up to v11) and iTunes (up to v10+) do
     not correctly handle ID3v2.3 tags with UTF-16BE+BOM
     encoding (they assume the data is UTF-16LE+BOM and either
@@ -602,3 +614,5 @@ Reference material:
 * http://trac.musepack.net/trac/wiki/SV8Specification
 * http://wyday.com/cuesharp/specification.php
 * http://www.sno.phy.queensu.ca/~phil/exiftool/TagNames/Nikon.html
+* http://www.codeproject.com/Articles/8295/MPEG-Audio-Frame-Header
+* http://dsd-guide.com/sites/default/files/white-papers/DSFFileFormatSpec_E.pdf

--- a/app/music.php
+++ b/app/music.php
@@ -45,10 +45,7 @@ use \OCA\Music\Utility\Helper;
 use \OCA\Music\Utility\Scanner;
 use OCP\AppFramework\IAppContainer;
 
-// in stable5 getid3 is already loaded
-if(!class_exists('getid3_exception')) {
-	require_once __DIR__ . '/../3rdparty/getID3/getid3/getid3.php';
-}
+require_once __DIR__ . '/../3rdparty/getID3/getid3/getid3.php';
 
 class Music extends App {
 


### PR DESCRIPTION
Update the getid3 library to version 1.9.12 patched with commit https://github.com/JamesHeinrich/getID3/commit/0e6c1a3bcef8219fede2c3ead13734296576bce5.

This should be considered a temporary solution. The library should be updated to the official version 1.9.13 once that is available.

Fixes #518.
Fixes #538.
Fixes #545.
