### PR TITLE
Apotek get id3 inclusion

### DIFF
--- a/app/music.php
+++ b/app/music.php
@@ -45,11 +45,6 @@ use \OCA\Music\Utility\Helper;
 use \OCA\Music\Utility\Scanner;
 use OCP\AppFramework\IAppContainer;
 
-// in stable5 getid3 is already loaded
-if(!class_exists('getid3_exception')) {
-	require_once __DIR__ . '/../3rdparty/getID3/getid3/getid3.php';
-}
-
 class Music extends App {
 
 	public function __construct(array $urlParams=array()){

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,5 @@
     "require-dev": {
         "behat/behat": "~3.0.15",
         "guzzlehttp/guzzle": "~5.0"
-    },
-    "require": {
-        "james-heinrich/getid3": "~1.9.12"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,8 @@
     "require-dev": {
         "behat/behat": "~3.0.15",
         "guzzlehttp/guzzle": "~5.0"
+    },
+    "require": {
+        "james-heinrich/getid3": "~1.9.12"
     }
 }

--- a/utility/extractorgetid3.php
+++ b/utility/extractorgetid3.php
@@ -14,6 +14,9 @@ namespace OCA\Music\Utility;
 
 use \OCA\Music\AppFramework\Core\Logger;
 
+// Only include when needed. Better ways to do this, but this
+// allow apps which use getID3 to be enabled at the same time.
+require_once __DIR__ . '/../3rdparty/getID3/getid3/getid3.php';
 /**
  * an extractor class for getID3
  */


### PR DESCRIPTION
This should address issue #551 . Loads getID3 library only when required by a process rather than during the load of the basic application. Allows for better interoperability between various OC media applications.