### PR TITLE
Refs #551: Include get3ID libs as needed

### DIFF
--- a/app/music.php
+++ b/app/music.php
@@ -45,11 +45,6 @@ use \OCA\Music\Utility\Helper;
 use \OCA\Music\Utility\Scanner;
 use OCP\AppFramework\IAppContainer;
 
-// in stable5 getid3 is already loaded
-if(!class_exists('getid3_exception')) {
-	require_once __DIR__ . '/../3rdparty/getID3/getid3/getid3.php';
-}
-
 class Music extends App {
 
 	public function __construct(array $urlParams=array()){

--- a/utility/extractorgetid3.php
+++ b/utility/extractorgetid3.php
@@ -14,6 +14,10 @@ namespace OCA\Music\Utility;
 
 use \OCA\Music\AppFramework\Core\Logger;
 
+// #551. Include get3ID only as needed. Moving this from
+// apps/music.php to the code that uses it.
+require_once __DIR__ . '/../3rdparty/getID3/getid3/getid3.php';
+
 /**
  * an extractor class for getID3
  */


### PR DESCRIPTION
Don't declare get3ID class at the basic app layer as it will conflict with other declarations simply by enabling the music app, whether in current use or not. Should fix #551