### PR TITLE
hand over ->fp for special WAV indexing

### DIFF
--- a/3rdparty/getID3/getid3/module.audio-video.riff.php
+++ b/3rdparty/getID3/getid3/module.audio-video.riff.php
@@ -1200,7 +1200,7 @@ $info['error'][] = 'WebP image parsing not supported in this version of getID3()
 					getid3_lib::IncludeDependency(GETID3_INCLUDEPATH.'module.tag.id3v2.php', __FILE__, true);
 
 					$getid3_temp = new getID3();
-					$getid3_temp->openfile($this->getid3->filename);
+					$getid3_temp->openfile($this->getid3->filename,$this->getid3->fp);
 					$getid3_id3v2 = new getid3_id3v2($getid3_temp);
 					$getid3_id3v2->StartingOffset = $thisfile_riff[$RIFFsubtype]['id3 '][0]['offset'] + 8;
 					if ($thisfile_riff[$RIFFsubtype]['id3 '][0]['valid'] = $getid3_id3v2->Analyze()) {


### PR DESCRIPTION
the local fp needs to be used here because in certain cases, a temporary pointer is used for ID3v2 in WAV files

related to your:
https://github.com/owncloud/music/commit/330fc142a27d441808cdc370202718928407a2f4

also patched in Audio Player:
https://github.com/Rello/audioplayer/commit/6aeb7028226227d45b566e6ecb00cab110d1a741

cheers!