### PR TITLE
Remove legacy call to vendor_script()

### DIFF
--- a/templates/main.php
+++ b/templates/main.php
@@ -6,8 +6,6 @@ $version = \OCP\Util::getVersion();
 if (version_compare(implode('.', $version), '7.8', '<=')) {
 	\OCP\Util::addScript('3rdparty', 'md5/md5.min');
 	\OCP\Util::addScript('music', 'vendor/underscore/underscore-min');
-} else {
-	vendor_script('blueimp-md5/js/md5');
 }
 
 // until ownCloud 8.2 OC.Backbone was not present

--- a/templates/main.php
+++ b/templates/main.php
@@ -3,10 +3,6 @@
 $version = \OCP\Util::getVersion();
 
 \OCP\Util::addScript('core', 'placeholder');
-if (version_compare(implode('.', $version), '7.8', '<=')) {
-	\OCP\Util::addScript('3rdparty', 'md5/md5.min');
-	\OCP\Util::addScript('music', 'vendor/underscore/underscore-min');
-}
 
 // until ownCloud 8.2 OC.Backbone was not present
 if($version[0] < 8 || $version[0] === 8 && $version[1] < 2) {


### PR DESCRIPTION
It causes the php handler to run forever (thus a gateway timeout error) on rendering `templates/main.php`. The reason is unknown, but JS md5 is not needed in music anyway, I can't find anywhere in javascript that invokes md5.

Server version: Nextcloud 12 alpha
Database: sqlite