### PR TITLE
Allow one album to cover several release years

### DIFF
--- a/app/music.php
+++ b/app/music.php
@@ -66,9 +66,9 @@ class Music extends App {
 				$c->query('URLGenerator'),
 				$c->query('AmpacheUserMapper'),
 				$c->query('AmpacheSessionMapper'),
-				$c->query('AlbumMapper'),
-				$c->query('ArtistMapper'),
-				$c->query('TrackMapper'),
+				$c->query('AlbumBusinessLayer'),
+				$c->query('ArtistBusinessLayer'),
+				$c->query('TrackBusinessLayer'),
 				$c->query('AmpacheUser'),
 				$c->query('RootFolder')
 			);

--- a/appframework/businesslayer/businesslayer.php
+++ b/appframework/businesslayer/businesslayer.php
@@ -69,11 +69,24 @@ abstract class BusinessLayer {
 
 	/**
 	 * Finds all entities
-	 * @param string $userId the name of the user for security reasons
-	 * @return array the entities
+	 * @param string $userId the name of the user
+	 * @param integer $limit
+	 * @param integer $offset
+	 * @return Entity[]
 	 */
-	public function findAll($userId){
-		return $this->mapper->findAll($userId);
+	public function findAll($userId, $limit=null, $offset=null){
+		return $this->mapper->findAll($userId, $limit, $offset);
+	}
+
+	/**
+	 * Return all entities with name matching the search criteria
+	 * @param string $name
+	 * @param string $userId
+	 * @param bool $fuzzy
+	 * @return Entity[]
+	 */
+	public function findAllByName($name, $userId, $fuzzy = false){
+		return $this->mapper->findAllByName($name, $userId, $fuzzy);
 	}
 
 	/**

--- a/appinfo/database.xml
+++ b/appinfo/database.xml
@@ -117,12 +117,6 @@
 				<length>256</length>
 			</field>
 			<field>
-				<name>year</name>
-				<type>integer</type>
-				<notnull>false</notnull>
-				<unsigned>true</unsigned>
-			</field>
-			<field>
 				<name>cover_file_id</name>
 				<type>integer</type>
 				<notnull>false</notnull>
@@ -209,6 +203,12 @@
 			</field>
 			<field>
 				<name>number</name>
+				<type>integer</type>
+				<notnull>false</notnull>
+				<unsigned>true</unsigned>
+			</field>
+			<field>
+				<name>year</name>
 				<type>integer</type>
 				<notnull>false</notnull>
 				<unsigned>true</unsigned>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<description>Music player and server for ownCloud</description>
 	<licence>AGPLv3</licence>
 	<author>Morris Jobke, Jan-Christoph Borchardt (design)</author>
-	<version>0.3.16</version>
+	<version>0.3.16.1</version>
 	<dependencies>
 		<owncloud min-version="8.1" max-version="10" />
 		<nextcloud min-version="9" max-version="13" />

--- a/businesslayer/trackbusinesslayer.php
+++ b/businesslayer/trackbusinesslayer.php
@@ -60,6 +60,16 @@ class TrackBusinessLayer extends BusinessLayer {
 	}
 
 	/**
+	 * Returns all tracks filtered by name (of track/album/artist)
+	 * @param string $name the name of the track/album/artist
+	 * @param string $userId the name of the user
+	 * @return \OCA\Music\Db\Track[] tracks
+	 */
+	public function findAllByNameRecursive($name, $userId){
+		return $this->mapper->findAllByNameRecursive($name, $userId);
+	}
+
+	/**
 	 * Returns the track for a file id
 	 * @param string $fileId the file id of the track
 	 * @param string $userId the name of the user
@@ -79,9 +89,26 @@ class TrackBusinessLayer extends BusinessLayer {
 	}
 
 	/**
+	 * @param integer $artistId
+	 * @return integer
+	 */
+	public function countByArtist($artistId){
+		return $this->mapper->countByArtist($artistId);
+	}
+
+	/**
+	 * @param integer $albumId
+	 * @return integer
+	 */
+	public function countByAlbum($albumId){
+		return $this->mapper->countByAlbum($albumId);
+	}
+
+	/**
 	 * Adds a track if it does not exist already or updates an existing track
 	 * @param string $title the title of the track
 	 * @param string $number the number of the track
+	 * @param string $year the year of the release
 	 * @param string $artistId the artist id of the track
 	 * @param string $albumId the album id of the track
 	 * @param string $fileId the file id of the track
@@ -92,11 +119,12 @@ class TrackBusinessLayer extends BusinessLayer {
 	 * @return \OCA\Music\Db\Track The added/updated track
 	 */
 	public function addOrUpdateTrack(
-			$title, $number, $artistId, $albumId, $fileId,
+			$title, $number, $year, $artistId, $albumId, $fileId,
 			$mimetype, $userId, $length=null, $bitrate=null){
 		$track = new Track();
 		$track->setTitle($title);
 		$track->setNumber($number);
+		$track->setYear($year);
 		$track->setArtistId($artistId);
 		$track->setAlbumId($albumId);
 		$track->setFileId($fileId);
@@ -185,13 +213,4 @@ class TrackBusinessLayer extends BusinessLayer {
 		return $result;
 	}
 
-	/**
-	 * Returns all tracks filtered by name (of track/album/artist)
-	 * @param string $name the name of the track/album/artist
-	 * @param string $userId the name of the user
-	 * @return \OCA\Music\Db\Track[] tracks
-	 */
-	public function findAllByNameRecursive($name, $userId){
-		return $this->mapper->findAllByNameRecursive($name, $userId);
-	}
 }

--- a/db/artistmapper.php
+++ b/db/artistmapper.php
@@ -31,9 +31,11 @@ class ArtistMapper extends BaseMapper {
 
 	/**
 	 * @param string $userId
+	 * @param integer $limit
+	 * @param integer $offset
 	 * @return Artist[]
 	 */
-	public function findAll($userId){
+	public function findAll($userId, $limit=null, $offset=null){
 		$sql = $this->makeSelectQuery('ORDER BY LOWER(`artist`.`name`)');
 		$params = array($userId);
 		return $this->findEntities($sql, $params);

--- a/db/track.php
+++ b/db/track.php
@@ -21,6 +21,8 @@ use \OCP\AppFramework\Db\Entity;
  * @method setTitle(string $title)
  * @method int getNumber()
  * @method setNumber(int $number)
+ * @method int getYear()
+ * @method setYear(int $year)
  * @method int getArtistId()
  * @method setArtistId(int $artistId)
  * @method Artist getArtist()
@@ -44,6 +46,7 @@ class Track extends Entity {
 
 	public $title;
 	public $number;
+	public $year;
 	public $artistId;
 	public $artist;
 	public $albumId;
@@ -58,6 +61,7 @@ class Track extends Entity {
 
 	public function __construct(){
 		$this->addType('number', 'int');
+		$this->addType('year', 'int');
 		$this->addType('artistId', 'int');
 		$this->addType('albumId', 'int');
 		$this->addType('length', 'int');

--- a/migration/premigration.php
+++ b/migration/premigration.php
@@ -41,7 +41,7 @@ class PreMigration implements IRepairStep {
 		}
 
 		// DB schema for tracks/albums/artists has been changed for 0.3.16
-		if (version_compare($installedVersion, '0.3.16', '<')) {
+		if (version_compare($installedVersion, '0.3.16.1', '<')) {
 			$sqls[] = 'DELETE FROM `*PREFIX*music_artists`';
 			$sqls[] = 'DELETE FROM `*PREFIX*music_albums`';
 			$sqls[] = 'DELETE FROM `*PREFIX*music_tracks`';
@@ -49,7 +49,7 @@ class PreMigration implements IRepairStep {
 		}
 
 		// Invalidate the cache if the previous version is new enough to have one.
-		// Even if this wasn't strictly necessary, it will anyway do no harm.
+		// This might not be strictly necessary on all migrations, but it will anyway do no harm.
 		if (version_compare($installedVersion, '0.3.15', '>=')) {
 			$sqls[] = 'DELETE FROM `*PREFIX*music_cache`';
 		}

--- a/templates/ampache/albums.php
+++ b/templates/ampache/albums.php
@@ -9,7 +9,7 @@ print '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>';
 			<artist id='<?php p($albumArtist?$albumArtist->getId():'')?>'><?php p($albumArtist->getNameString($_['l10n'])) ?></artist>
 			<tracks><?php p($album->getTrackCount())?></tracks>
 			<rating>0</rating>
-			<year><?php p($album->getYear())?></year>
+			<year><?php p($album->yearToAPI())?></year>
 			<disk><?php p($album->getDisk())?></disk>
 			<art><?php $cid = $album->getCoverFileId(); if ($cid){p($_['urlGenerator']->getAbsoluteURL($_['urlGenerator']->linkToRoute('music.ampache.ampache'))); ?>?action=_get_cover&amp;filter=<?php p($album->getId());?>&amp;auth=<?php p($_['authtoken']);} ?></art>
 			<preciserating>0</preciserating>

--- a/tests/php/integration/data/HelperCleanupData.json
+++ b/tests/php/integration/data/HelperCleanupData.json
@@ -5,9 +5,9 @@
     { "id" : 1003, "name": "The Third Artist",  "user_id": "integration", "hash": "57543454357564563456536754465434" }
   ],
   "music_albums" : [
-    { "id" : 1001, "name": "Testalbum",  "user_id": "integration", "year":"2016", "cover_file_id":"0", "album_artist_id": 1001, "hash": "23905689023734908234345983498572"}
+    { "id" : 1001, "name": "Testalbum",  "user_id": "integration", "cover_file_id":"0", "album_artist_id": 1001, "hash": "23905689023734908234345983498572"}
   ],
   "music_tracks" : [
-    { "id" : "1001", "user_id": "integration", "title" : "Testtitel 1", "number" : "1", "artist_id" : "1001", "album_id": "1001" , "length" : "100", "file_id" : "0", "bitrate" : "123", "mimetype" : "audio/mpeg"}
+    { "id" : "1001", "user_id": "integration", "title" : "Testtitel 1", "number" : "1", "year":"2016", "artist_id" : "1001", "album_id": "1001" , "length" : "100", "file_id" : "0", "bitrate" : "123", "mimetype" : "audio/mpeg"}
   ]
 }

--- a/tests/php/unit/businesslayer/AlbumBusinessLayerTest.php
+++ b/tests/php/unit/businesslayer/AlbumBusinessLayerTest.php
@@ -12,9 +12,6 @@
 
 namespace OCA\Music\BusinessLayer;
 
-use \OCP\AppFramework\Db\DoesNotExistException;
-use \OCP\AppFramework\Db\MultipleObjectsReturnedException;
-
 use \OCA\Music\Db\Album;
 
 
@@ -140,7 +137,6 @@ class AlbumBusinessLayerTest extends \PHPUnit_Framework_TestCase {
 
 	public function testAddOrUpdateAlbum(){
 		$name = 'test';
-		$year = 2002;
 		$artistId = 1;
 		$disc = 1;
 
@@ -148,7 +144,7 @@ class AlbumBusinessLayerTest extends \PHPUnit_Framework_TestCase {
 			->method('insertOrUpdate')
 			->will($this->returnValue($this->albums[0]));
 
-		$album = $this->albumBusinessLayer->addOrUpdateAlbum($name, $year, $disc, $artistId, $this->userId);
+		$album = $this->albumBusinessLayer->addOrUpdateAlbum($name, $disc, $artistId, $this->userId);
 		$this->assertEquals($this->albums[0], $album);
 	}
 

--- a/tests/php/unit/businesslayer/ArtistBusinessLayerTest.php
+++ b/tests/php/unit/businesslayer/ArtistBusinessLayerTest.php
@@ -12,9 +12,6 @@
 
 namespace OCA\Music\BusinessLayer;
 
-use \OCP\AppFramework\Db\DoesNotExistException;
-use \OCP\AppFramework\Db\MultipleObjectsReturnedException;
-
 use \OCA\Music\Db\Artist;
 
 

--- a/tests/php/unit/businesslayer/TrackBusinessLayerTest.php
+++ b/tests/php/unit/businesslayer/TrackBusinessLayerTest.php
@@ -12,9 +12,6 @@
 
 namespace OCA\Music\BusinessLayer;
 
-use \OCP\AppFramework\Db\DoesNotExistException;
-use \OCP\AppFramework\Db\MultipleObjectsReturnedException;
-
 use \OCA\Music\Db\Track;
 
 
@@ -96,7 +93,7 @@ class TrackBusinessLayerTest extends \PHPUnit_Framework_TestCase {
 			->method('insertOrUpdate')
 			->will($this->returnValue($track));
 
-		$result = $this->trackBusinessLayer->addOrUpdateTrack(null, null, null, null, $fileId, null, $this->userId);
+		$result = $this->trackBusinessLayer->addOrUpdateTrack(null, null, null, null, null, $fileId, null, $this->userId);
 		$this->assertEquals($track, $result);
 	}
 

--- a/tests/php/unit/controller/APIControllerTest.php
+++ b/tests/php/unit/controller/APIControllerTest.php
@@ -168,7 +168,7 @@ class APIControllerTest extends ControllerTestUtility {
 		$album = new Album();
 		$album->setId(4);
 		$album->setName('The name');
-		$album->setYear(2013);
+		$album->setYears([2011, 2013]);
 		$album->setCoverFileId(5);
 		$album->setDisk(1);
 		$album->setArtistIds(array(3));
@@ -303,7 +303,7 @@ class APIControllerTest extends ControllerTestUtility {
 		$album = new Album();
 		$album->setId(4);
 		$album->setName('The name');
-		$album->setYear(2013);
+		$album->setYears([2013]);
 		$album->setCoverFileId(5);
 		$album->setDisk(1);
 		$album->setArtistIds(array(3));
@@ -418,7 +418,7 @@ class APIControllerTest extends ControllerTestUtility {
 		$album = new Album();
 		$album->setId(3);
 		$album->setName('The name');
-		$album->setYear(2013);
+		$album->setYears([1999, 2000, 2013]);
 		$album->setCoverFileId(5);
 		$album->setDisk(1);
 		$album->setArtistIds(array(3));
@@ -502,7 +502,7 @@ class APIControllerTest extends ControllerTestUtility {
 		$album1 = new Album();
 		$album1->setId(3);
 		$album1->setName('The name');
-		$album1->setYear(2013);
+		$album1->setYears([2013]);
 		$album1->setCoverFileId(5);
 		$album1->setDisk(1);
 		$album1->setArtistIds(array(1));
@@ -510,7 +510,7 @@ class APIControllerTest extends ControllerTestUtility {
 		$album2 = new Album();
 		$album2->setId(4);
 		$album2->setName('The album name');
-		$album2->setYear(2003);
+		$album2->setYears([]);
 		$album2->setCoverFileId(7);
 		$album2->setDisk(1);
 		$album2->setArtistIds(array(3,5));
@@ -541,7 +541,7 @@ class APIControllerTest extends ControllerTestUtility {
 				'uri' => null,
 				'slug' => '4-the-album-name',
 				'id' => 4,
-				'year' => 2003,
+				'year' => null,
 				'disk' => 1,
 				'artists' => array(
 					array('id' => 3, 'uri' => null),
@@ -561,7 +561,7 @@ class APIControllerTest extends ControllerTestUtility {
 		$album1 = new Album();
 		$album1->setId(3);
 		$album1->setName('The name');
-		$album1->setYear(2013);
+		$album1->setYears([2013]);
 		$album1->setCoverFileId(5);
 		$album1->setDisk(1);
 		$album1->setArtistIds(array(1));
@@ -569,7 +569,7 @@ class APIControllerTest extends ControllerTestUtility {
 		$album2 = new Album();
 		$album2->setId(4);
 		$album2->setName('The album name');
-		$album2->setYear(2003);
+		$album2->setYears([2003]);
 		$album2->setCoverFileId(7);
 		$album2->setDisk(1);
 		$album2->setArtistIds(array(3,5));
@@ -711,7 +711,7 @@ class APIControllerTest extends ControllerTestUtility {
 		$album = new Album();
 		$album->setId(3);
 		$album->setName('The name');
-		$album->setYear(2013);
+		$album->setYears([2013]);
 		$album->setCoverFileId(5);
 		$album->setDisk(1);
 		$album->setArtistIds(array(1));
@@ -795,7 +795,7 @@ class APIControllerTest extends ControllerTestUtility {
 		$album = new Album();
 		$album->setId(3);
 		$album->setName('The name');
-		$album->setYear(2013);
+		$album->setYears([2013]);
 		$album->setCoverFileId(5);
 		$album->setDisk(1);
 		$album->setArtistIds(array(1));
@@ -909,7 +909,7 @@ class APIControllerTest extends ControllerTestUtility {
 		$album = new Album();
 		$album->setId(3);
 		$album->setName('The name');
-		$album->setYear(2013);
+		$album->setYears([2013]);
 		$album->setCoverFileId(5);
 		$album->setDisk(1);
 		$album->setArtistIds(array(1));

--- a/tests/php/unit/db/albumTest.php
+++ b/tests/php/unit/db/albumTest.php
@@ -27,7 +27,7 @@ class AlbumTest extends \PHPUnit_Framework_TestCase {
 		$album = new Album();
 		$album->setId(3);
 		$album->setName('The name');
-		$album->setYear(2013);
+		$album->setYears([1999, 2000, 2013]);
 		$album->setCoverFileId(5);
 		$album->setDisk(1);
 		$album->setArtistIds(array(1,2));

--- a/utility/scanner.php
+++ b/utility/scanner.php
@@ -144,11 +144,11 @@ class Scanner extends PublicEmitter {
 
 			// add/update album and get album entity
 			$album = $this->albumBusinessLayer->addOrUpdateAlbum(
-					$meta['album'], $meta['year'], $meta['discNumber'], $albumArtistId, $userId);
+					$meta['album'], $meta['discNumber'], $albumArtistId, $userId);
 			$albumId = $album->getId();
 
 			// add/update track and get track entity
-			$track = $this->trackBusinessLayer->addOrUpdateTrack($meta['title'], $meta['trackNumber'],
+			$track = $this->trackBusinessLayer->addOrUpdateTrack($meta['title'], $meta['trackNumber'], $meta['year'],
 					$artistId, $albumId, $fileId, $mimetype, $userId, $meta['length'], $meta['bitrate']);
 
 			// if present, use the embedded album art as cover for the respective album


### PR DESCRIPTION
- Previously, an album could have only one year. Hence, if the user had tagged tracks of an album with different years (say, with original release years instead of the album release year), the album was divided and shown as several albums.
- With this change, the year is indexed per-track. If and album has several years, the UI shows a year range like "2002 - 2015". The Shiva and Ampache APIs require that album has a single year; for these, the largest year found from album is used.
- This is a change in database schema, and requires database rebuild. This is enforced by incrementing the version number to 0.3.16.1.
- As part of this change, AmpacheController has been altered to use BusinessLayer classes instead of Album-/Artist-/TrackMapper. This was technically necessary only for the AlbumMapper, but it is better not to skip layers of abstraction on the others, either.
- Fixes #279
- Fixes #307