### PR TITLE
Fixed the buffer progress in Firefox.

### DIFF
--- a/js/app/playerwrapper.js
+++ b/js/app/playerwrapper.js
@@ -125,6 +125,11 @@ PlayerWrapper.prototype.fromURL = function(url, mime) {
 					var bufEnd = (bufCount > 0) ? this.buffered[bufCount-1].end : 0;
 					self.trigger('buffer', bufEnd / this.durationEstimate * 100);
 				},
+				onsuspend: function() {
+					// Work around an issue in Firefox where the last buffered position will never equal the duration.
+					// This fixes the buffer progress bar not reaching 100% despite the file being fully buffered.
+					if (typeof InstallTrigger !== 'undefined') self.trigger('buffer', 100);
+				},
 				onfinish: function() {
 					self.trigger('end');
 				},

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -1202,6 +1202,11 @@ PlayerWrapper.prototype.fromURL = function(url, mime) {
 					var bufEnd = (bufCount > 0) ? this.buffered[bufCount-1].end : 0;
 					self.trigger('buffer', bufEnd / this.durationEstimate * 100);
 				},
+				onsuspend: function() {
+					// Work around an issue in Firefox where the last buffered position will never equal the duration.
+					// This fixes the buffer progress bar not reaching 100% despite the file being fully buffered.
+					if (typeof InstallTrigger !== 'undefined') self.trigger('buffer', 100);
+				},
 				onfinish: function() {
 					self.trigger('end');
 				},


### PR DESCRIPTION
When playing a file in Firefox you will notice the buffer progress bar always stops at around 90-99%.
This is because the "progress" event doesn't fire when buffering has completed in Firefox.
Setting the buffer progress to 100% in the "suspend" event works around this issue as it only seems to be fired after buffering has been completed.
Note that the behavior in Chrome is a different one, where the "suspend" event is fired when buffering is suspended (_duh_).