### PR TITLE
Ampache: also accept authentication in "ssid" key

### DIFF
--- a/middleware/ampachemiddleware.php
+++ b/middleware/ampachemiddleware.php
@@ -62,8 +62,14 @@ class AmpacheMiddleware extends Middleware {
 		$this->isAmpacheCall = $annotationReader->hasAnnotation('AmpacheAPI');
 
 		// don't try to authenticate for the handshake request
-		if($this->isAmpacheCall && $this->request['action'] !== 'handshake'){
-			$token = $this->request['auth'];
+        if($this->isAmpacheCall && $this->request['action'] !== 'handshake'){
+            $token = null;
+            if (!empty($this->request['auth'])) {
+                $token = $this->request['auth'];
+            } else if (!empty($this->request['ssid'])) {
+                $token = $this->request['ssid'];
+            }
+
 			if($token !== null && $token !== '') {
 				$user = $this->ampacheSessionMapper->findByToken($token);
 				if($user !== false && array_key_exists('user_id', $user)) {

--- a/middleware/ampachemiddleware.php
+++ b/middleware/ampachemiddleware.php
@@ -62,13 +62,13 @@ class AmpacheMiddleware extends Middleware {
 		$this->isAmpacheCall = $annotationReader->hasAnnotation('AmpacheAPI');
 
 		// don't try to authenticate for the handshake request
-        if($this->isAmpacheCall && $this->request['action'] !== 'handshake'){
-            $token = null;
-            if (!empty($this->request['auth'])) {
-                $token = $this->request['auth'];
-            } else if (!empty($this->request['ssid'])) {
-                $token = $this->request['ssid'];
-            }
+		if($this->isAmpacheCall && $this->request['action'] !== 'handshake') {
+			$token = null;
+			if (!empty($this->request['auth'])) {
+				$token = $this->request['auth'];
+			} else if (!empty($this->request['ssid'])) {
+				$token = $this->request['ssid'];
+			}
 
 			if($token !== null && $token !== '') {
 				$user = $this->ampacheSessionMapper->findByToken($token);


### PR DESCRIPTION
Until now, we only accepted the authentication token in the "auth"
key. This is the same as in Ampache.

However, for the URL of a song, Ampache passes the authentication
token in the "ssid" key. Some clients expect this key to have
this name, for example the Ampache Plugin for Rhythmbox, as shipped
with Ubuntu.

After this change, Rhythmbox works fine.

There is also a client-side fix for this problem:
<https://github.com/lotan/rhythmbox-ampache/commit/0d233e3282caea3f6a80c943bb414597a1afb733>