### PR TITLE
Fix the Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,31 +1,33 @@
 language: php
 sudo: false
 php:
-  - 5.6
   - 7.0
-  - 7.1
-  - 7.2
 
 env:
   global:
-    - CORE_BRANCH=master
     - OC_PASS=ampache
   matrix:
-    - DB=mysql;CLOUD=owncloud
-    - DB=pgsql;CLOUD=owncloud
-    - DB=mysql;CLOUD=nextcloud
-    - DB=pgsql;CLOUD=nextcloud
+    - DB=mysql;CLOUD=owncloud;CORE_BRANCH=master
+    - DB=pgsql;CLOUD=owncloud;CORE_BRANCH=master
+    - DB=mysql;CLOUD=nextcloud;CORE_BRANCH=stable13
+    - DB=pgsql;CLOUD=nextcloud;CORE_BRANCH=stable13
 
 matrix:
   include:
-    #- php: 5.6
-      #env: DB=mysql CLOUD=owncloud CORE_BRANCH=stable8.1
-    - php: 7
-      env: DB=mysql CLOUD=owncloud CORE_BRANCH=stable8.2
-    - php: 7
-      env: DB=mysql CLOUD=owncloud CORE_BRANCH=stable9
-    - php: 7
-      env: DB=mysql CLOUD=owncloud CORE_BRANCH=stable9.1
+    - php: 5.6
+      env: DB=mysql CLOUD=nextcloud CORE_BRANCH=stable13
+    - php: 7.1
+      env: DB=mysql CLOUD=nextcloud CORE_BRANCH=stable13
+    - php: 7.2
+      env: DB=mysql CLOUD=nextcloud CORE_BRANCH=stable13
+    - env: DB=mysql CLOUD=nextcloud CORE_BRANCH=stable11
+    - env: DB=mysql CLOUD=nextcloud CORE_BRANCH=stable12
+    - env: DB=mysql CLOUD=nextcloud CORE_BRANCH=master
+    - env: DB=mysql CLOUD=owncloud CORE_BRANCH=stable8.2
+    - env: DB=mysql CLOUD=owncloud CORE_BRANCH=stable9
+    - env: DB=mysql CLOUD=owncloud CORE_BRANCH=stable9.1
+  allow_failures:
+    - env: DB=mysql CLOUD=nextcloud CORE_BRANCH=master
   fast_finish: true
 
 branches:


### PR DESCRIPTION
- Nextcloud master branch nowadays contains the server version 14.0.0-alpha, but the Music app is not compatible with it. Hence, test against the stable13 instead of the master branch.
- One test run is still made against Nexcloud master but this is specifically allowed to fail
- Furthermore, Nextcoud 14.0.0 requires PHP 7.x so testing the nextcloud master with PHP 5.6 made even less sense
- Added also test jobs for nextcloud stable11 and stable12
- Limited the total amount of test jobs by not including all combinations: different PHP versions are now tested only with nextcloud stable13.