### PR TITLE
Implements --group option for the occ music commands owncloud/music#584

### DIFF
--- a/app/music.php
+++ b/app/music.php
@@ -268,6 +268,10 @@ class Music extends App {
 			return $c->getServer()->getUserManager();
 		});
 
+		$container->registerService('GroupManager', function($c) {
+			return $c->getServer()->getGroupManager();
+		});
+
 		/**
 		 * Utility
 		 */

--- a/appinfo/register_command.php
+++ b/appinfo/register_command.php
@@ -21,14 +21,17 @@ $c = $app->getContainer();
 
 $application->add(new OCA\Music\Command\Scan(
 		$c->query('UserManager'),
+		$c->query('GroupManager'),
 		$c->query('Scanner')
 ));
 $application->add(new OCA\Music\Command\ResetDatabase(
 		$c->query('UserManager'),
+		$c->query('GroupManager'),
 		$c->query('Maintenance')
 ));
 $application->add(new OCA\Music\Command\ResetCache(
 		$c->query('UserManager'),
+		$c->query('GroupManager'),
 		$c->query('Cache')
 ));
 $application->add(new OCA\Music\Command\Cleanup(

--- a/command/basecommand.php
+++ b/command/basecommand.php
@@ -61,6 +61,7 @@ abstract class BaseCommand extends Command {
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$argsValid = true;
+		$users = [];
 		if (!$input->getOption('all')) {
 			if (count($input->getArgument('user_id'))===0
 					&& count($input->getOption('group'))===0) {

--- a/command/resetcache.php
+++ b/command/resetcache.php
@@ -22,9 +22,10 @@ class ResetCache extends BaseCommand {
 	/** @var Cache */
 	private $cache;
 
-	public function __construct(\OCP\IUserManager $userManager, Cache $cache) {
+	public function __construct(\OCP\IUserManager $userManager,
+			\OCP\IGroupManager $groupManager,  Cache $cache) {
 		$this->cache = $cache;
-		parent::__construct($userManager);
+		parent::__construct($userManager, $groupManager);
 	}
 
 	protected function doConfigure() {
@@ -33,12 +34,11 @@ class ResetCache extends BaseCommand {
 			->setDescription('drop data cached by the music app for performance reasons');
 	}
 
-	protected function doExecute(InputInterface $input, OutputInterface $output) {
+	protected function doExecute(InputInterface $input, OutputInterface $output, $users) {
 		if ($input->getOption('all')) {
 			$output->writeln("Drop cache for <info>all users</info>");
 			$this->cache->remove();
 		} else {
-			$users = $input->getArgument('user_id');
 			foreach($users as $user) {
 				$output->writeln("Drop cache for <info>$user</info>");
 				$this->cache->remove($user);

--- a/command/resetdatabase.php
+++ b/command/resetdatabase.php
@@ -24,9 +24,10 @@ class ResetDatabase extends BaseCommand {
 	/** @var Maintenance */
 	private $maintenance;
 
-	public function __construct(\OCP\IUserManager $userManager, Maintenance $maintenance) {
+	public function __construct(\OCP\IUserManager $userManager,
+			\OCP\IGroupManager $groupManager, Maintenance $maintenance) {
 		$this->maintenance = $maintenance;
-		parent::__construct($userManager);
+		parent::__construct($userManager, $groupManager);
 	}
 
 	protected function doConfigure() {
@@ -35,12 +36,11 @@ class ResetDatabase extends BaseCommand {
 			->setDescription('drop metadata indexed by the music app (artists, albums, tracks, playlists)');
 	}
 
-	protected function doExecute(InputInterface $input, OutputInterface $output) {
+	protected function doExecute(InputInterface $input, OutputInterface $output, $users) {
 		if ($input->getOption('all')) {
 			$output->writeln("Drop tables for <info>all users</info>");
 			$this->maintenance->resetDb(null, true);
 		} else {
-			$users = $input->getArgument('user_id');
 			foreach($users as $user) {
 				$output->writeln("Drop tables for <info>$user</info>");
 				$this->maintenance->resetDb($user);

--- a/command/scan.php
+++ b/command/scan.php
@@ -30,9 +30,10 @@ class Scan extends BaseCommand {
 	 */
 	private $scanner;
 
-	public function __construct(\OCP\IUserManager $userManager, $scanner) {
+	public function __construct(\OCP\IUserManager $userManager,
+			\OCP\IGroupManager $groupManager, $scanner) {
 		$this->scanner = $scanner;
-		parent::__construct($userManager);
+		parent::__construct($userManager, $groupManager);
 	}
 
 	protected function doConfigure() {
@@ -54,7 +55,7 @@ class Scan extends BaseCommand {
 		;
 	}
 
-	protected function doExecute(InputInterface $input, OutputInterface $output) {
+	protected function doExecute(InputInterface $input, OutputInterface $output, $users) {
 		if (!$input->getOption('debug')) {
 			$this->scanner->listen('\OCA\Music\Utility\Scanner', 'update', function($path) use ($output) {
 				$output->writeln("Scanning <info>$path</info>");
@@ -64,8 +65,6 @@ class Scan extends BaseCommand {
 		if ($input->getOption('all')) {
 			$users = $this->userManager->search('');
 			$users = array_map(function($u){return $u->getUID();}, $users);
-		} else {
-			$users = $input->getArgument('user_id');
 		}
 
 		foreach ($users as $user) {


### PR DESCRIPTION
Here is the change for the --group option on the occ command.
It does not work exactly the same way as what was done on the files:scan --group.
files:scan --group explodes the group parameters with comma (to allow multiple groups), which doesn't seem to be right as owncloud allows group names with commas in it.