### PR TITLE
Custom track list directive

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -136,8 +136,16 @@ h1 span:hover .play {
 	cursor: pointer;
 }
 
+track-list.collapsed .collapsible {
+	display: none;
+}
+
 .track-list > li.more-less {
 	padding-left: 21px;
+}
+
+track-list:not(.collapsed) li.more-less:not(.collapsible) {
+	display: none;
 }
 
 .play-pause {
@@ -171,6 +179,7 @@ h1 span:hover .play {
 }
 
 .current:not(.playing) .play-pause,
+#app-view .current.playing:hover .play-pause,
 #app-view .current.playing:hover > .play-pause {
 	background-image: url(../img/pause-big.svg)
 }
@@ -180,6 +189,7 @@ h1 span:hover .play {
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)";
 	filter: alpha(opacity = 50);
 	opacity: .5;
+	display: inline;
 }
 
 .alphabet-navigation {

--- a/js/app/controllers/overviewcontroller.js
+++ b/js/app/controllers/overviewcontroller.js
@@ -50,6 +50,11 @@ angular.module('Music').controller('OverviewController', [
 		}
 
 		$scope.playTrack = function(track) {
+			// Allow passing an ID as well as a track object
+			if (!isNaN(track)) {
+				track = libraryService.getTrack(track);
+			}
+
 			// play/pause if currently playing track clicked
 			var currentTrack = $scope.$parent.currentTrack;
 			if (currentTrack && track.id === currentTrack.id) {
@@ -61,9 +66,14 @@ angular.module('Music').controller('OverviewController', [
 				window.location.hash = '#/track/' + track.id;
 
 				var album = libraryService.findAlbumOfTrack(track.id);
+
 				playTracks(album.tracks, album.tracks.indexOf(track));
 			}
 		};
+
+		$scope.$on('playTrack', function (event, trackId) {
+			$scope.playTrack(trackId);
+		});
 
 		$scope.playAlbum = function(album) {
 			// update URL hash

--- a/js/app/directives/tracklist.js
+++ b/js/app/directives/tracklist.js
@@ -1,0 +1,258 @@
+/**
+ * ownCloud - Music app
+ *
+ * @author Moritz Meißelbach
+ * @copyright 2017 Moritz Meißelbach <moritz@meisselba.ch>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+/**
+ * This custom directive produces a self-contained track list widget that updates its list items according to the global playback state and user interaction.
+ * Handling this with markup alone would produce a large amount of watchers.
+ */
+
+
+angular.module('Music').directive('trackList', ['$window', '$rootScope', '$interpolate', function ($window, $rootScope, $interpolate) {
+
+	var tpl = '<div class="play-pause"></div>' +
+		'<span data-number="{{number}}" class="muted">{{number}}</span> ' +
+		'<span title="{{titleAtt}}">{{title}}</span>';
+
+	var trackRenderer = $interpolate(tpl);
+
+	return {
+		restrict: 'E',
+		link: function (scope, element, attrs) {
+			var rendered = false;
+			var expanded = false;
+			var listContainer;
+			var tracks = scope.album.tracks;
+			var moreText = scope.$eval(attrs.moreText);
+			var lessText = scope.$eval(attrs.lessText);
+
+			var listeners = [
+				$rootScope.$watch('currentTrack', function () {
+					requestAnimationFrame(render);
+				}),
+				$rootScope.$watch('playing', function () {
+					requestAnimationFrame(render);
+				})
+			];
+
+			/**
+			 * Render markup (once) and set classes according to current scope (always)
+			 */
+			function render () {
+				if (!rendered) {
+					var widget = document.createDocumentFragment(),
+						trackListFragment = renderTrackList();
+
+					listContainer = document.createElement('ul');
+					listContainer.className = 'track-list';
+
+					listContainer.appendChild(trackListFragment);
+					widget.appendChild(listContainer);
+					element.html(widget);
+					element.addClass('collapsed');
+					rendered = true;
+				}
+				/**
+				 * Set classes for the currently active list item
+				 */
+				var elems = listContainer.querySelectorAll(".playing, .current");
+				[].forEach.call(elems, function (el) {
+					el.classList.remove('current');
+					el.classList.remove('playing');
+				});
+				if (!scope.currentTrack) {
+					return;
+				}
+				var playing = listContainer.querySelector('[data-track-id="' + scope.currentTrack.id + '"]');
+				if (playing) {
+					playing.classList.add('current');
+					if ($rootScope.playing) {
+						playing.classList.add('playing');
+					} else {
+						playing.classList.remove('playing');
+					}
+				}
+			}
+
+			/**
+			 * Create the list of individual tracks. Skips after reaching the "toggle threshold"
+			 * so only tracks that are initially visible are actually being rendered
+			 *
+			 * @returns {DocumentFragment}
+			 */
+			function renderTrackList () {
+				var trackListFragment = document.createDocumentFragment();
+
+				for (var index = 0; index < tracks.length; index++) {
+					if (index > 4 && tracks.length !== 6) {
+						break;
+					}
+					var track = tracks[index];
+					var className = '';
+					trackListFragment.appendChild(getTrackNode(track, className));
+
+				}
+				if (tracks.length > 6) {
+					var lessEl = document.createElement('li');
+					var moreEl = document.createElement('li');
+
+					lessEl.innerHTML = lessText;
+					lessEl.classList = 'muted more-less collapsible';
+					moreEl.innerHTML = moreText;
+					moreEl.classList = 'muted more-less';
+					trackListFragment.appendChild(lessEl);
+					trackListFragment.appendChild(moreEl);
+				}
+				return trackListFragment;
+			}
+
+			/**
+			 * Renders a single Track HTML Node
+			 *
+			 * @param track
+			 * @param className
+			 * @returns {HTMLLIElement}
+			 */
+			function getTrackNode (track, className) {
+				var listItem = document.createElement('li');
+				var newElement = trackRenderer(prepareTrackTemplateData(track));
+				listItem.setAttribute('data-track-id', track.id);
+				listItem.setAttribute('draggable', true);
+				listItem.className = className;
+				listItem.innerHTML = newElement;
+				return listItem;
+			}
+
+			/**
+			 * Adds those tracks that aren't initially visible to the listContainer
+			 *
+			 * @returns {boolean}
+			 */
+			function renderHiddenTracks () {
+				if (tracks.length < 6) {
+					return;
+				}
+				var trackListFragment = document.createDocumentFragment();
+
+				for (var index = 5; index < tracks.length; index++) {
+					var track = tracks[index];
+					var className = 'collapsible';
+					trackListFragment.appendChild(getTrackNode(track, className));
+				}
+				var toggle = listContainer.getElementsByClassName('muted more-less collapsible');
+				listContainer.insertBefore(trackListFragment, toggle[0]);
+				return true;
+			}
+
+			/**
+			 * Checks if the track artist differs from the album artist
+			 *
+			 * @param track
+			 * @returns {boolean}
+			 */
+			function hasDifferentArtist (track) {
+				return (track.artistId !== scope.artist.id);
+			}
+
+			/**
+			 * Formats a track title string for displaying in the template
+			 *
+			 * @param track
+			 * @param plaintext
+			 */
+			function getTitleString (track, plaintext) {
+				var att = track.title;
+				if (hasDifferentArtist(track)) {
+					var artistName = ' (' + track.artistName + ') ';
+					if (!plaintext) {
+						artistName = ' <div class="muted">' + artistName + '</div>';
+					}
+					att += artistName;
+				}
+
+				return att;
+			}
+
+			/**
+			 * Prepares template data.
+			 * 
+			 * @param track
+			 */
+			function prepareTrackTemplateData (track) {
+				var data = Object.assign({}, track);//Clone the track data
+				data.title = getTitleString(track);
+				data.titleAtt = getTitleString(track, true);
+				if (data.number) {
+					data.number += '.';
+				}
+				return data;
+			}
+
+			/**
+			 * Click handler for list items
+			 */
+			element.on('click', 'li', function (event) {
+				var trackId = this.getAttribute('data-track-id');
+				if (trackId) {
+					scope.$emit('playTrack', trackId);
+					scope.$apply();
+					return;
+				}
+				expanded = expanded || renderHiddenTracks();
+				element.toggleClass('collapsed');
+			});
+
+			/**
+			 * Drag&Drop compatibility
+			 */
+			element.on('dragstart', 'li', function (e) {
+				if (e.originalEvent) {
+					e.dataTransfer = e.originalEvent.dataTransfer;
+				}
+				var trackId = this.getAttribute('data-track-id');
+				var track = _.findWhere(tracks, {id: parseInt(trackId)});
+				var dragData = {'track': track};
+				var offset = {x: e.offsetX, y: e.offsetY};
+				var transferDataObject = {
+					data: dragData,
+					channel: 'defaultchannel',
+					offset: offset
+				};
+				var transferDataText = angular.toJson(transferDataObject);
+				e.dataTransfer.setData('text', transferDataText);
+				e.dataTransfer.effectAllowed = 'copyMove';
+				$rootScope.$broadcast('ANGULAR_DRAG_START', e, 'defaultchannel', transferDataObject);
+			});
+
+			element.on('dragend', 'li', function (e) {
+				$rootScope.$broadcast('ANGULAR_DRAG_END', e, 'defaultchannel');
+			});
+
+			scope.$on('$destroy', function () {
+				element.off();
+				[].forEach.call(listeners, function (el) {
+					el();
+				});
+			});
+
+		}
+	};
+}]);

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -290,6 +290,11 @@ angular.module('Music').controller('OverviewController', [
 		}
 
 		$scope.playTrack = function(track) {
+			// Allow passing an ID as well as a track object
+			if (!isNaN(track)) {
+				track = libraryService.getTrack(track);
+			}
+
 			// play/pause if currently playing track clicked
 			var currentTrack = $scope.$parent.currentTrack;
 			if (currentTrack && track.id === currentTrack.id) {
@@ -301,9 +306,14 @@ angular.module('Music').controller('OverviewController', [
 				window.location.hash = '#/track/' + track.id;
 
 				var album = libraryService.findAlbumOfTrack(track.id);
+
 				playTracks(album.tracks, album.tracks.indexOf(track));
 			}
 		};
+
+		$scope.$on('playTrack', function (event, trackId) {
+			$scope.playTrack(trackId);
+		});
 
 		$scope.playAlbum = function(album) {
 			// update URL hash
@@ -1082,6 +1092,243 @@ angular.module('Music').directive('sidebarListItem', function() {
 		replace: true
 	};
 });
+
+/**
+ * This custom directive produces a self-contained track list widget that updates its list items according to the global playback state and user interaction.
+ * Handling this with markup alone would produce a large amount of watchers.
+ */
+
+
+angular.module('Music').directive('trackList', ['$window', '$rootScope', '$interpolate', function ($window, $rootScope, $interpolate) {
+
+	var tpl = '<div class="play-pause"></div>' +
+		'<span data-number="{{number}}" class="muted">{{number}}</span> ' +
+		'<span title="{{titleAtt}}">{{title}}</span>';
+
+	var trackRenderer = $interpolate(tpl);
+
+	return {
+		restrict: 'E',
+		link: function (scope, element, attrs) {
+			var rendered = false;
+			var expanded = false;
+			var listContainer;
+			var tracks = scope.album.tracks;
+			var moreText = scope.$eval(attrs.moreText);
+			var lessText = scope.$eval(attrs.lessText);
+
+			var listeners = [
+				$rootScope.$watch('currentTrack', function () {
+					requestAnimationFrame(render);
+				}),
+				$rootScope.$watch('playing', function () {
+					requestAnimationFrame(render);
+				})
+			];
+
+			/**
+			 * Render markup (once) and set classes according to current scope (always)
+			 */
+			function render () {
+				if (!rendered) {
+					var widget = document.createDocumentFragment(),
+						trackListFragment = renderTrackList();
+
+					listContainer = document.createElement('ul');
+					listContainer.className = 'track-list';
+
+					listContainer.appendChild(trackListFragment);
+					widget.appendChild(listContainer);
+					element.html(widget);
+					element.addClass('collapsed');
+					rendered = true;
+				}
+				/**
+				 * Set classes for the currently active list item
+				 */
+				var elems = listContainer.querySelectorAll(".playing, .current");
+				[].forEach.call(elems, function (el) {
+					el.classList.remove('current');
+					el.classList.remove('playing');
+				});
+				if (!scope.currentTrack) {
+					return;
+				}
+				var playing = listContainer.querySelector('[data-track-id="' + scope.currentTrack.id + '"]');
+				if (playing) {
+					playing.classList.add('current');
+					if ($rootScope.playing) {
+						playing.classList.add('playing');
+					} else {
+						playing.classList.remove('playing');
+					}
+				}
+			}
+
+			/**
+			 * Create the list of individual tracks. Skips after reaching the "toggle threshold"
+			 * so only tracks that are initially visible are actually being rendered
+			 *
+			 * @returns {DocumentFragment}
+			 */
+			function renderTrackList () {
+				var trackListFragment = document.createDocumentFragment();
+
+				for (var index = 0; index < tracks.length; index++) {
+					if (index > 4 && tracks.length !== 6) {
+						break;
+					}
+					var track = tracks[index];
+					var className = '';
+					trackListFragment.appendChild(getTrackNode(track, className));
+
+				}
+				if (tracks.length > 6) {
+					var lessEl = document.createElement('li');
+					var moreEl = document.createElement('li');
+
+					lessEl.innerHTML = lessText;
+					lessEl.classList = 'muted more-less collapsible';
+					moreEl.innerHTML = moreText;
+					moreEl.classList = 'muted more-less';
+					trackListFragment.appendChild(lessEl);
+					trackListFragment.appendChild(moreEl);
+				}
+				return trackListFragment;
+			}
+
+			/**
+			 * Renders a single Track HTML Node
+			 *
+			 * @param track
+			 * @param className
+			 * @returns {HTMLLIElement}
+			 */
+			function getTrackNode (track, className) {
+				var listItem = document.createElement('li');
+				var newElement = trackRenderer(prepareTrackTemplateData(track));
+				listItem.setAttribute('data-track-id', track.id);
+				listItem.setAttribute('draggable', true);
+				listItem.className = className;
+				listItem.innerHTML = newElement;
+				return listItem;
+			}
+
+			/**
+			 * Adds those tracks that aren't initially visible to the listContainer
+			 *
+			 * @returns {boolean}
+			 */
+			function renderHiddenTracks () {
+				if (tracks.length < 6) {
+					return;
+				}
+				var trackListFragment = document.createDocumentFragment();
+
+				for (var index = 5; index < tracks.length; index++) {
+					var track = tracks[index];
+					var className = 'collapsible';
+					trackListFragment.appendChild(getTrackNode(track, className));
+				}
+				var toggle = listContainer.getElementsByClassName('muted more-less collapsible');
+				listContainer.insertBefore(trackListFragment, toggle[0]);
+				return true;
+			}
+
+			/**
+			 * Checks if the track artist differs from the album artist
+			 *
+			 * @param track
+			 * @returns {boolean}
+			 */
+			function hasDifferentArtist (track) {
+				return (track.artistId !== scope.artist.id);
+			}
+
+			/**
+			 * Formats a track title string for displaying in the template
+			 *
+			 * @param track
+			 * @param plaintext
+			 */
+			function getTitleString (track, plaintext) {
+				var att = track.title;
+				if (hasDifferentArtist(track)) {
+					var artistName = ' (' + track.artistName + ') ';
+					if (!plaintext) {
+						artistName = ' <div class="muted">' + artistName + '</div>';
+					}
+					att += artistName;
+				}
+
+				return att;
+			}
+
+			/**
+			 * Prepares template data.
+			 * 
+			 * @param track
+			 */
+			function prepareTrackTemplateData (track) {
+				var data = Object.assign({}, track);//Clone the track data
+				data.title = getTitleString(track);
+				data.titleAtt = getTitleString(track, true);
+				if (data.number) {
+					data.number += '.';
+				}
+				return data;
+			}
+
+			/**
+			 * Click handler for list items
+			 */
+			element.on('click', 'li', function (event) {
+				var trackId = this.getAttribute('data-track-id');
+				if (trackId) {
+					scope.$emit('playTrack', trackId);
+					scope.$apply();
+					return;
+				}
+				expanded = expanded || renderHiddenTracks();
+				element.toggleClass('collapsed');
+			});
+
+			/**
+			 * Drag&Drop compatibility
+			 */
+			element.on('dragstart', 'li', function (e) {
+				if (e.originalEvent) {
+					e.dataTransfer = e.originalEvent.dataTransfer;
+				}
+				var trackId = this.getAttribute('data-track-id');
+				var track = _.findWhere(tracks, {id: parseInt(trackId)});
+				var dragData = {'track': track};
+				var offset = {x: e.offsetX, y: e.offsetY};
+				var transferDataObject = {
+					data: dragData,
+					channel: 'defaultchannel',
+					offset: offset
+				};
+				var transferDataText = angular.toJson(transferDataObject);
+				e.dataTransfer.setData('text', transferDataText);
+				e.dataTransfer.effectAllowed = 'copyMove';
+				$rootScope.$broadcast('ANGULAR_DRAG_START', e, 'defaultchannel', transferDataObject);
+			});
+
+			element.on('dragend', 'li', function (e) {
+				$rootScope.$broadcast('ANGULAR_DRAG_END', e, 'defaultchannel');
+			});
+
+			scope.$on('$destroy', function () {
+				element.off();
+				[].forEach.call(listeners, function (el) {
+					el();
+				});
+			});
+
+		}
+	};
+}]);
 
 angular.module('Music').factory('ArtistFactory', ['Restangular', '$rootScope', function (Restangular, $rootScope) {
 	return {

--- a/templates/partials/overview.php
+++ b/templates/partials/overview.php
@@ -10,45 +10,25 @@
 		<div bindonce class="album-area" ng-repeat="album in artist.albums">
 			<h2 bo-id="'album-' + album.id">
 				<div ng-click="playAlbum(album)"
-					bo-title="album.name + ((album.year) ? ' (' + album.year + ')' : '')"
-					ui-draggable="true" drag="getDraggable('album', album)">
+					 bo-title="album.name + ((album.year) ? ' (' + album.year + ')' : '')"
+					 ui-draggable="true" drag="getDraggable('album', album)">
 					<span bo-text="album.name"></span> <span bo-if="album.year" class="muted" bo-text="'(' + album.year + ')'"></span>
 				</div>
 			</h2>
 			<div ng-click="playAlbum(album)" class="albumart" cover="{{ album.cover }}" albumart="{{ album.name }}"></div>
 			<img ng-click="playAlbum(album)" class="play overlay svg" alt="{{ 'Play' | translate }}"
-				src="<?php p(OCP\image_path('music', 'play-big.svg')) ?>" />
-			<!-- variable "limit" toogles length of track list for each album -->
-			<ul class="track-list" ng-init="trackcount = album.tracks.length; limit.count = (trackcount == 6) ? 6 : 5">
-				<li bindonce
-					bo-id="'track-' + track.id" 
-					ng-click="playTrack(track)"
-					ui-draggable="true" drag="getDraggable('track', track)"
-					ng-repeat="track in album.tracks | limitTo:limit.count"
-					bo-title="track.title + ((track.artistId != artist.id) ? '  (' + track.artistName + ')' : '')"
-					ng-class="{current: currentTrack.id == track.id, playing: playing}"
-				>
-					<div class="play-pause" />
-					<span bo-if="track.number" class="muted" bo-text="track.number + '.'"></span>
-					<span bo-text="track.title"></span>
-					<span bo-if="track.artistId != artist.id" class="muted" bo-text="'&nbsp;(' + track.artistName +')'"></span>
-				</li>
-				<li class="muted more-less" translate translate-n="trackcount"
-					translate-plural="Show all {{ trackcount }} songs …"
-					ng-click="limit.count = trackcount"
-					ng-hide="trackcount <= 6 || limit.count > 6"
-					>Show all {{ trackcount }} songs …</li>
-				<li class="muted more-less"
-					ng-click="limit.count = 5"
-					ng-hide="limit.count <= 6" translate>Show less …</li>
-			</ul>
+				 src="<?php p(OCP\image_path('music', 'play-big.svg')) ?>" />
+			<track-list
+					more-text="'Show all {{ album.tracks.length }} songs …' | translate"
+					less-text="'Show less …' | translate"
+			/>
 		</div>
 	</div>
 
 	<div ng-show="artists" class="alphabet-navigation" ng-class="{started: started}" resize>
 		<a du-smooth-scroll="{{ letter }}" offset="{{ scrollOffset() }}"
-			ng-repeat="letter in letters" 
-			ng-class="{available: letterAvailable[letter], filler: ($index % 2) == 1}">
+		   ng-repeat="letter in letters"
+		   ng-class="{available: letterAvailable[letter], filler: ($index % 2) == 1}">
 			<span class="letter-content">{{ letter }}</span>
 		</a>
 	</div>


### PR DESCRIPTION
## Description

We have touched this topic before in #599.

The current template for track lists involves a lot of logic and handles track display very dynamically, resulting in a large amount of watchers and CPU load during repaints. This pull request introduces a custom directive that renders and updates the track list with minimal overhead.

## Details
The list is now rendered only once (with as much vanilla JS as possible) and handles collapsing/expanding and track selection mostly via CSS. Click and drag events are implemented as a single delegated event handler, so we only need one per track list.

## Usage
The new markup boils down to this:
```html
<track-list
	click-handler="playTrack"
	more-text="'Show all {{ album.tracks.length }} songs …' | translate"
	less-text="'Show less …' | translate"
/>
```

The tracks, artist and album are then pulled from the scope, where 2 watchers are added.

## Benchmarks
I grabbed a few screenshots to illustrate the changes.
My test installation has a bit more than 500 songs. As each album/track list currently introduces more and more watchers, I expect the improvements to be even more drastic with larger collections.

### Initial page load (Batarang)

#### Before:
![pageload-master](https://user-images.githubusercontent.com/4208996/35652228-07205e74-06e3-11e8-91ec-d8daad8ca67c.png)

#### After:
![pageload-widget](https://user-images.githubusercontent.com/4208996/35652324-5dde9ca8-06e3-11e8-9761-9bc008884995.png)

The amount of watchers has halved as did the average digest time.
### Initial page load (general)
#### Before:
![pageload2-master](https://user-images.githubusercontent.com/4208996/35652347-702d2938-06e3-11e8-9c0b-f1fcbbc44027.png)
#### After:
![pageload2-widget](https://user-images.githubusercontent.com/4208996/35652351-75954cac-06e3-11e8-8a74-489ae6228343.png)

The whole music app is now loaded a full 2 seconds faster

### Music playback (Batarang)

#### Before:
![playback-master](https://user-images.githubusercontent.com/4208996/35652372-943ab67e-06e3-11e8-991e-cded11c7665c.png)

#### After:
![playback-widget](https://user-images.githubusercontent.com/4208996/35652374-98932dd2-06e3-11e8-8a66-0fee122b6556.png)

This wasn't particularly slow earlier, but it's still nice to see such big improvements during playback as well.

## Things to watch out for.

- Drag&Drop could be a bit shaky. It worked wherever I tested it (-->adding tracks to playlists), but since the directive needs full control over its markup and tries its hardest to keep DOM manipulation and event handlers at a minimum, we cannot throw regular "ui-draggable" attributes on it (because that would require compiling the markup with angular and then spoiling most of the performance gains). The solution for this was to copy/reimplement what "ui-draggable" does to that it it is tricked into thinking it receives one of its own draggable elements.

- I did not fully understand how the l10n pipeline works (especially for pluralized strings). The more/less-texts might not work, but they don't seem to be translated right now anyway.

- It is currently not possible to define or alter the list item markup in the template. I initially planned to make the directive consume its innerHTML to use it as a template, but it did not feel right to leave it like that. Since the markup is only interpolated (-> variable replacement) instead of being fully compiled by angular, any of angular's custom directives and attributes would not work.





