### PR TITLE
Do no use subselect in updateFolderCover method, for performance reasons

### DIFF
--- a/db/albummapper.php
+++ b/db/albummapper.php
@@ -155,19 +155,25 @@ class AlbumMapper extends BaseMapper {
 	 * @return true if one or more albums were influenced
 	 */
 	public function updateFolderCover($coverFileId, $folderId){
-		$sql = 'UPDATE `*PREFIX*music_albums`
-				SET `cover_file_id` = ?
-				WHERE `cover_file_id` IS NULL AND `id` IN (
-					SELECT DISTINCT `tracks`.`album_id`
+		$sql = 'SELECT DISTINCT `tracks`.`album_id`
 					FROM `*PREFIX*music_tracks` `tracks`
 					JOIN `*PREFIX*filecache` `files` ON `tracks`.`file_id` = `files`.`fileid`
-					WHERE `files`.`parent` = ?
-				)';
-		$params = array($coverFileId, $folderId);
+					WHERE `files`.`parent` = ?';
+		$params = array($folderId);
 		$result = $this->execute($sql, $params);
-		return $result->rowCount() > 0;
+	
+		if ($result->rowCount()){
+			$sql = 'UPDATE `*PREFIX*music_albums`
+					SET `cover_file_id` = ?
+					WHERE `cover_file_id` IS NULL AND `id` IN (?)';
+			$params = array($coverFileId, join(",", $result->fetchAll(\PDO::FETCH_COLUMN)));
+			$result = $this->execute($sql, $params);
+			return $result->rowCount() > 0;
+		}
+		
+		return false;
 	}
-
+	
 	/**
 	 * @param integer $coverFileId
 	 * @param integer $albumId


### PR DESCRIPTION
We are using OwnCloud in a large installation (> 30.000 users). After enabling the music app, we started noticing a gradual increase in database server load.

![3m](https://user-images.githubusercontent.com/23337494/37710434-f03486f8-2d0d-11e8-82d9-3c5f6c6b882c.png)

We eventually tracked it down to this query:
UPDATE `oc_music_albums` SET `cover_file_id` = ? WHERE `cover_file_id` IS NULL AND `id` IN ( SELECT DISTINCT `tracks`.`album_id` FROM `oc_music_tracks` `tracks` JOIN `oc_filecache` `files` ON `tracks`.`file_id` = `files`.`fileid` WHERE `files`.`parent` = ? )

Which in some cases took multiple seconds to complete (on beefy hardware). The subselect within yielded 0 rows so you'd expect the complete query to be quick, but the problem is that the outer query yielded a lot of rows (over 20.000), so we ran into this limitation of MySQL:

https://dev.mysql.com/doc/mysql-reslimits-excerpt/5.5/en/subquery-restrictions.html

"A typical case for poor IN subquery performance is when the subquery returns a small number of rows but the outer query returns a large number of rows to be compared to the subquery result."

By executing the two queries separately, the MySQL optimizer works a lot better and the server load dropped instantly.

![screenshot_2018-03-20_15-16-09](https://user-images.githubusercontent.com/23337494/37710451-f87ea32a-2d0d-11e8-979e-08828f7f30e0.png)
