### PR TITLE
Use the custom tracklist directive also in the "All tracks" view

### DIFF
--- a/css/style-playlist.css
+++ b/css/style-playlist.css
@@ -5,7 +5,7 @@
  * later. See the COPYING file.
  *
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
- * @copyright Pauli Järvinen 2016
+ * @copyright Pauli Järvinen 2016 - 2018
  */
 
 .playlist-area {
@@ -35,6 +35,7 @@
 	padding-top: 5px;
 	border: 1px solid transparent;
 	white-space: nowrap;
+	display: table;
 }
 
 .playlist-area .track-list.insert-above > li.drag-hover {

--- a/css/style.css
+++ b/css/style.css
@@ -132,7 +132,8 @@ h1 span:hover .play {
 	cursor: pointer
 }
 
-.album-area .track-list li * {
+.album-area .track-list li *,
+#alltracks-area .track-list li * {
 	cursor: pointer;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -5,7 +5,9 @@
  * later. See the COPYING file.
  *
  * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
  * @copyright Morris Jobke 2013, 2014
+ * @copyright Pauli Järvinen 2016 - 2018
  */
 
 #notification a {
@@ -129,7 +131,7 @@ h1 span:hover .play {
 	text-overflow: ellipsis;
 	overflow: hidden;
 	white-space: nowrap;
-	cursor: pointer
+	cursor: pointer;
 }
 
 .album-area .track-list li *,
@@ -159,7 +161,7 @@ track-list:not(.collapsed) li.more-less:not(.collapsible) {
 	background-size: 100% 100%;
 	background-position: center;
 	background-repeat: no-repeat;
-	
+
 	/* opacity */
 	-ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=60)";
 	filter: alpha(opacity = 60);

--- a/js/app/controllers/alltracksviewcontroller.js
+++ b/js/app/controllers/alltracksviewcontroller.js
@@ -10,10 +10,8 @@
 
 
 angular.module('Music').controller('AllTracksViewController', [
-	'$rootScope', '$scope', '$routeParams', 'playlistService', 'libraryService',
-	'gettext', 'gettextCatalog', 'Restangular', '$timeout',
-	function ($rootScope, $scope, $routeParams, playlistService, libraryService,
-			gettext, gettextCatalog, Restangular , $timeout) {
+	'$rootScope', '$scope', 'playlistService', 'libraryService', '$timeout',
+	function ($rootScope, $scope, playlistService, libraryService, $timeout) {
 
 		$scope.tracks = null;
 		$rootScope.currentView = window.location.hash;
@@ -81,10 +79,6 @@ angular.module('Music').controller('AllTracksViewController', [
 		subscribe('artistsLoaded', function () {
 			initViewFromRoute();
 		});
-
-		function listIsPlaying() {
-			return ($rootScope.playingView === $rootScope.currentView);
-		}
 
 		function initViewFromRoute() {
 			if (libraryService.collectionLoaded()) {

--- a/js/app/controllers/alltracksviewcontroller.js
+++ b/js/app/controllers/alltracksviewcontroller.js
@@ -1,0 +1,101 @@
+/**
+ * ownCloud - Music app
+ *
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
+ *
+ * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
+ * @copyright Pauli Järvinen 2018
+ */
+
+
+angular.module('Music').controller('AllTracksViewController', [
+	'$rootScope', '$scope', '$routeParams', 'playlistService', 'libraryService',
+	'gettext', 'gettextCatalog', 'Restangular', '$timeout',
+	function ($rootScope, $scope, $routeParams, playlistService, libraryService,
+			gettext, gettextCatalog, Restangular , $timeout) {
+
+		$scope.tracks = null;
+		$rootScope.currentView = window.location.hash;
+
+		// $rootScope listeneres must be unsubscribed manually when the control is destroyed
+		var unsubFuncs = [];
+
+		function subscribe(event, handler) {
+			unsubFuncs.push( $rootScope.$on(event, handler) );
+		}
+
+		$scope.$on('$destroy', function () {
+			_.each(unsubFuncs, function(func) { func(); });
+		});
+
+		// Call playlistService to play all songs in the current playlist from the beginning
+		$scope.playAll = function() {
+			playlistService.setPlaylist($scope.tracks);
+			playlistService.publish('play');
+		};
+
+		// Play the list, starting from a specific track
+		$scope.playTrack = function(trackId) {
+			// play/pause if currently playing list item clicked
+			if ($scope.$parent.currentTrack && $scope.$parent.currentTrack.id === trackId) {
+				playlistService.publish('togglePlayback');
+			}
+			// on any other list item, start playing the list from this item
+			else {
+				var index = _.findIndex($scope.tracks, function(i) {return i.track.id == trackId;});
+				playlistService.setPlaylist($scope.tracks, index);
+				playlistService.publish('play');
+			}
+		};
+
+		/**
+		 * Gets track data to be dislayed in the tracklist directive
+		 */
+		$scope.getTrackData = function(listItem, index, scope) {
+			var track = listItem.track;
+			var title = track.artistName + ' - ' + track.title;
+			return {
+				title: title,
+				tooltip: title,
+				number: index + 1,
+				id: track.id
+			};
+		};
+
+		$scope.getDraggable = function(trackId) {
+			return { track: libraryService.getTrack(trackId) };
+		};
+
+		subscribe('scrollToTrack', function(event, trackId) {
+			if ($scope.$parent) {
+				$scope.$parent.scrollToItem('track-' + trackId);
+			}
+		});
+
+		// Init happens either immediately (after making the loading animation visible)
+		// or once aritsts have been loaded
+		$timeout(function() {
+			initViewFromRoute();
+		});
+		subscribe('artistsLoaded', function () {
+			initViewFromRoute();
+		});
+
+		function listIsPlaying() {
+			return ($rootScope.playingView === $rootScope.currentView);
+		}
+
+		function initViewFromRoute() {
+			if (libraryService.collectionLoaded()) {
+				$scope.tracks = libraryService.getTracksInAlphaOrder();
+				$rootScope.loading = false;
+			}
+		}
+
+		subscribe('deactivateView', function() {
+			$rootScope.$emit('viewDeactivated');
+		});
+
+	}
+]);

--- a/js/app/controllers/alltracksviewcontroller.js
+++ b/js/app/controllers/alltracksviewcontroller.js
@@ -74,21 +74,27 @@ angular.module('Music').controller('AllTracksViewController', [
 		// Init happens either immediately (after making the loading animation visible)
 		// or once aritsts have been loaded
 		$timeout(function() {
-			initViewFromRoute();
+			initView();
 		});
 		subscribe('artistsLoaded', function () {
-			initViewFromRoute();
+			initView();
 		});
 
-		function initViewFromRoute() {
+		function initView() {
 			if (libraryService.collectionLoaded()) {
 				$scope.tracks = libraryService.getTracksInAlphaOrder();
-				$rootScope.loading = false;
+				$timeout(function() {
+					$rootScope.loading = false;
+				});
 			}
 		}
 
 		subscribe('deactivateView', function() {
-			$rootScope.$emit('viewDeactivated');
+			// The small delay may help in bringing up the load indicator a bit faster
+			// on huge collections (tens of thousands of tracks)
+			$timeout(function() {
+				$rootScope.$emit('viewDeactivated');
+			}, 100);
 		});
 
 	}

--- a/js/app/controllers/alltracksviewcontroller.js
+++ b/js/app/controllers/alltracksviewcontroller.js
@@ -73,11 +73,12 @@ angular.module('Music').controller('AllTracksViewController', [
 
 		// Init happens either immediately (after making the loading animation visible)
 		// or once aritsts have been loaded
-		$timeout(function() {
-			initView();
-		});
+		$timeout(initView);
+
 		subscribe('artistsLoaded', function () {
-			initView();
+			// Nullify any previous tracks to force tracklist directive recreation
+			$scope.tracks = null;
+			$timeout(initView);
 		});
 
 		function initView() {

--- a/js/app/controllers/overviewcontroller.js
+++ b/js/app/controllers/overviewcontroller.js
@@ -207,9 +207,7 @@ angular.module('Music').controller('OverviewController', [
 			$timeout(showMore);
 		}
 
-		subscribe('artistsLoaded', function() {
-			showMore();
-		});
+		subscribe('artistsLoaded', showMore);
 
 		function showLess() {
 			$scope.incrementalLoadLimit -= INCREMENTAL_LOAD_STEP;

--- a/js/app/controllers/overviewcontroller.js
+++ b/js/app/controllers/overviewcontroller.js
@@ -73,10 +73,6 @@ angular.module('Music').controller('OverviewController', [
 			}
 		};
 
-		$scope.$on('playTrack', function (event, trackId) {
-			$scope.playTrack(trackId);
-		});
-
 		$scope.playAlbum = function(album) {
 			// update URL hash
 			window.location.hash = '#/album/' + album.id;
@@ -104,6 +100,37 @@ angular.module('Music').controller('OverviewController', [
 			draggable[type] = draggedElement;
 			return draggable;
 		};
+
+		$scope.getTrackDraggable = function(trackId) {
+			return $scope.getDraggable('track', libraryService.getTrack(trackId));
+		};
+
+		/**
+		 * Gets track data to be dislayed in the tracklist directive
+		 */
+		$scope.getTrackData = function(track, index, scope) {
+			return {
+				title: getTitleString(track, scope.artist, false),
+				tooltip: getTitleString(track, scope.artist, true),
+				number: track.number,
+				id: track.id
+			};
+		};
+
+		/**
+		 * Formats a track title string for displaying in tracklist directive
+		 */
+		function getTitleString(track, artist, plaintext) {
+			var att = track.title;
+			if (track.artistId !== artist.id) {
+				var artistName = ' (' + track.artistName + ') ';
+				if (!plaintext) {
+					artistName = ' <div class="muted">' + artistName + '</div>';
+				}
+				att += artistName;
+			}
+			return att;
+		}
 
 		// emited on end of playlist by playerController
 		subscribe('playlistEnded', function() {

--- a/js/app/controllers/playlistviewcontroller.js
+++ b/js/app/controllers/playlistviewcontroller.js
@@ -29,7 +29,7 @@ angular.module('Music').controller('PlaylistViewController', [
 			unsubFuncs.push( $rootScope.$on(event, handler) );
 		}
 
-		$scope.$on('$destroy', function () {
+		$scope.$on('$destroy', function() {
 			_.each(unsubFuncs, function(func) { func(); });
 		});
 
@@ -134,15 +134,9 @@ angular.module('Music').controller('PlaylistViewController', [
 
 		// Init happens either immediately (after making the loading animation visible)
 		// or once both aritsts and playlists have been loaded
-		$timeout(function() {
-			initViewFromRoute();
-		});
-		subscribe('artistsLoaded', function () {
-			initViewFromRoute();
-		});
-		subscribe('playlistsLoaded', function () {
-			initViewFromRoute();
-		});
+		$timeout(initViewFromRoute);
+		subscribe('artistsLoaded', initViewFromRoute);
+		subscribe('playlistsLoaded', initViewFromRoute);
 
 		function listIsPlaying() {
 			return ($rootScope.playingView === $rootScope.currentView);

--- a/js/app/controllers/playlistviewcontroller.js
+++ b/js/app/controllers/playlistviewcontroller.js
@@ -15,7 +15,7 @@ angular.module('Music').controller('PlaylistViewController', [
 	'$rootScope', '$scope', '$routeParams', 'playlistService', 'libraryService',
 	'gettext', 'gettextCatalog', 'Restangular', '$timeout',
 	function ($rootScope, $scope, $routeParams, playlistService, libraryService,
-			gettext, gettextCatalog, Restangular , $timeout) {
+			gettext, gettextCatalog, Restangular, $timeout) {
 
 		var INCREMENTAL_LOAD_STEP = 1000;
 		$scope.incrementalLoadLimit = INCREMENTAL_LOAD_STEP;
@@ -109,7 +109,7 @@ angular.module('Music').controller('PlaylistViewController', [
 		};
 
 		$scope.allowDrop = function(draggable, dstIndex) {
-			return $scope.playlist && draggable.srcIndex != dstIndex;
+			return draggable.srcIndex != dstIndex;
 		};
 
 		$scope.updateHoverStyle = function(dstIndex) {

--- a/js/app/controllers/playlistviewcontroller.js
+++ b/js/app/controllers/playlistviewcontroller.js
@@ -173,10 +173,6 @@ angular.module('Music').controller('PlaylistViewController', [
 						window.location.hash = '#/';
 					}
 				}
-				else {
-					$scope.playlist = null;
-					$scope.tracks = libraryService.getTracksInAlphaOrder();
-				}
 				$timeout(showMore);
 			}
 		}

--- a/js/app/directives/tracklist.js
+++ b/js/app/directives/tracklist.js
@@ -1,32 +1,25 @@
 /**
  * ownCloud - Music app
  *
- * @author Moritz Meißelbach
- * @copyright 2017 Moritz Meißelbach <moritz@meisselba.ch>
+ * This file is licensed under the Affero General Public License version 3 or
+ * later. See the COPYING file.
  *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
- * License as published by the Free Software Foundation; either
- * version 3 of the License, or any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
- *
- * You should have received a copy of the GNU Affero General Public
- * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ * @author Moritz Meißelbach <moritz@meisselba.ch>
+ * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
+ * @copyright 2017 Moritz Meißelbach
+ * @copyright 2018 Pauli Järvinen
  *
  */
 
 
 /**
- * This custom directive produces a self-contained track list widget that updates its list items according to the global playback state and user interaction.
+ * This custom directive produces a self-contained track list widget that updates
+ * its list items according to the global playback state and user interaction.
  * Handling this with markup alone would produce a large amount of watchers.
  */
 
-
-angular.module('Music').directive('trackList', ['$window', '$rootScope', '$interpolate', function ($window, $rootScope, $interpolate) {
+angular.module('Music').directive('trackList', ['$rootScope', '$interpolate',
+function ($rootScope, $interpolate) {
 
 	var tpl = '<div class="play-pause"></div>' +
 		'<span class="muted">{{ number ? number + ".&nbsp;" : "" }}</span>' +

--- a/js/app/directives/tracklist.js
+++ b/js/app/directives/tracklist.js
@@ -84,7 +84,7 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 				});
 
 				if (scope.currentTrack) {
-					var playing = listContainer.querySelector('[data-track-id="' + scope.currentTrack.id + '"]');
+					var playing = listContainer.querySelector('#track-' + scope.currentTrack.id);
 					if (playing) {
 						playing.classList.add('current');
 						if ($rootScope.playing) {
@@ -142,7 +142,6 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 				var trackData = getTrackData(track, index, scope);
 				var newElement = trackRenderer(trackData);
 				listItem.id = 'track-' + trackData.id;
-				listItem.setAttribute('data-track-id', trackData.id);
 				listItem.setAttribute('draggable', true);
 				listItem.className = className;
 				listItem.innerHTML = newElement;
@@ -164,13 +163,21 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 				listContainer.insertBefore(trackListFragment, toggle[0]);
 			}
 
+			function trackIdFromElementId(elemId) {
+				if (elemId && elemId.substring(0, 6) === 'track-') {
+					return parseInt(elemId.split('-')[1]);
+				} else {
+					return null;
+				}
+			}
+
 			/**
 			 * Click handler for list items
 			 */
 			element.on('click', 'li', function (event) {
-				var trackId = this.getAttribute('data-track-id');
+				var trackId = trackIdFromElementId(this.id);
 				if (trackId) {
-					playTrack(parseInt(trackId));
+					playTrack(trackId);
 					scope.$apply();
 				}
 				else { // "show more/less" item
@@ -189,7 +196,7 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 				if (e.originalEvent) {
 					e.dataTransfer = e.originalEvent.dataTransfer;
 				}
-				var trackId = this.getAttribute('data-track-id');
+				var trackId = trackIdFromElementId(this.id);
 				var offset = {x: e.offsetX, y: e.offsetY};
 				var transferDataObject = {
 					data: getDraggable(trackId),

--- a/js/app/directives/tracklist.js
+++ b/js/app/directives/tracklist.js
@@ -110,10 +110,8 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 					tracksToShow = collapseLimit - 1;
 				}
 
-				for (var index = 0; index < tracksToShow; index++) {
-					var track = tracks[index];
-					var className = '';
-					trackListFragment.appendChild(getTrackNode(track, index, className));
+				for (var i = 0; i < tracksToShow; i++) {
+					trackListFragment.appendChild(getTrackNode(tracks[i], i));
 				}
 
 				if (tracks.length > collapseLimit) {
@@ -133,8 +131,9 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 			/**
 			 * Renders a single Track HTML Node
 			 *
-			 * @param track
-			 * @param className
+			 * @param object track
+			 * @param int index
+			 * @param string className (optional)
 			 * @returns {HTMLLIElement}
 			 */
 			function getTrackNode (track, index, className) {
@@ -143,7 +142,9 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 				var newElement = trackRenderer(trackData);
 				listItem.id = 'track-' + trackData.id;
 				listItem.setAttribute('draggable', true);
-				listItem.className = className;
+				if (className) {
+					listItem.className = className;
+				}
 				listItem.innerHTML = newElement;
 				return listItem;
 			}
@@ -154,10 +155,8 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 			function renderHiddenTracks () {
 				var trackListFragment = document.createDocumentFragment();
 
-				for (var index = collapseLimit - 1; index < tracks.length; index++) {
-					var track = tracks[index];
-					var className = 'collapsible';
-					trackListFragment.appendChild(getTrackNode(track, index, className));
+				for (var i = collapseLimit - 1; i < tracks.length; i++) {
+					trackListFragment.appendChild(getTrackNode(tracks[i], i, 'collapsible'));
 				}
 				var toggle = listContainer.getElementsByClassName('muted more-less collapsible');
 				listContainer.insertBefore(trackListFragment, toggle[0]);

--- a/js/config/app.js
+++ b/js/config/app.js
@@ -50,6 +50,11 @@ angular.module('Music', ['restangular', 'duScroll', 'gettext', 'ngRoute', 'ang-d
 				templateUrl:'playlistview.html'
 			};
 
+			var allTracksControllerConfig = {
+				controller:'AllTracksViewController',
+				templateUrl:'alltracksview.html'
+			};
+
 			var settingsControllerConfig = {
 				controller:'SettingsViewController',
 				templateUrl:'settingsview.html'
@@ -67,7 +72,7 @@ angular.module('Music', ['restangular', 'duScroll', 'gettext', 'ngRoute', 'ang-d
 				.when('/track/:id',            overviewControllerConfig)
 				.when('/file/:id',             overviewControllerConfig)
 				.when('/playlist/:playlistId', playlistControllerConfig)
-				.when('/alltracks',            playlistControllerConfig)
+				.when('/alltracks',            allTracksControllerConfig)
 				.when('/settings',             settingsControllerConfig);
 		}
 	])

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -1467,10 +1467,8 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 					tracksToShow = collapseLimit - 1;
 				}
 
-				for (var index = 0; index < tracksToShow; index++) {
-					var track = tracks[index];
-					var className = '';
-					trackListFragment.appendChild(getTrackNode(track, index, className));
+				for (var i = 0; i < tracksToShow; i++) {
+					trackListFragment.appendChild(getTrackNode(tracks[i], i));
 				}
 
 				if (tracks.length > collapseLimit) {
@@ -1490,8 +1488,9 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 			/**
 			 * Renders a single Track HTML Node
 			 *
-			 * @param track
-			 * @param className
+			 * @param object track
+			 * @param int index
+			 * @param string className (optional)
 			 * @returns {HTMLLIElement}
 			 */
 			function getTrackNode (track, index, className) {
@@ -1500,7 +1499,9 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 				var newElement = trackRenderer(trackData);
 				listItem.id = 'track-' + trackData.id;
 				listItem.setAttribute('draggable', true);
-				listItem.className = className;
+				if (className) {
+					listItem.className = className;
+				}
 				listItem.innerHTML = newElement;
 				return listItem;
 			}
@@ -1511,10 +1512,8 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 			function renderHiddenTracks () {
 				var trackListFragment = document.createDocumentFragment();
 
-				for (var index = collapseLimit - 1; index < tracks.length; index++) {
-					var track = tracks[index];
-					var className = 'collapsible';
-					trackListFragment.appendChild(getTrackNode(track, index, className));
+				for (var i = collapseLimit - 1; i < tracks.length; i++) {
+					trackListFragment.appendChild(getTrackNode(tracks[i], i, 'collapsible'));
 				}
 				var toggle = listContainer.getElementsByClassName('muted more-less collapsible');
 				listContainer.insertBefore(trackListFragment, toggle[0]);

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -127,21 +127,27 @@ angular.module('Music').controller('AllTracksViewController', [
 		// Init happens either immediately (after making the loading animation visible)
 		// or once aritsts have been loaded
 		$timeout(function() {
-			initViewFromRoute();
+			initView();
 		});
 		subscribe('artistsLoaded', function () {
-			initViewFromRoute();
+			initView();
 		});
 
-		function initViewFromRoute() {
+		function initView() {
 			if (libraryService.collectionLoaded()) {
 				$scope.tracks = libraryService.getTracksInAlphaOrder();
-				$rootScope.loading = false;
+				$timeout(function() {
+					$rootScope.loading = false;
+				});
 			}
 		}
 
 		subscribe('deactivateView', function() {
-			$rootScope.$emit('viewDeactivated');
+			// The small delay may help in bringing up the load indicator a bit faster
+			// on huge collections (tens of thousands of tracks)
+			$timeout(function() {
+				$rootScope.$emit('viewDeactivated');
+			}, 100);
 		});
 
 	}

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -63,10 +63,8 @@ angular.module('Music', ['restangular', 'duScroll', 'gettext', 'ngRoute', 'ang-d
 	]);
 
 angular.module('Music').controller('AllTracksViewController', [
-	'$rootScope', '$scope', '$routeParams', 'playlistService', 'libraryService',
-	'gettext', 'gettextCatalog', 'Restangular', '$timeout',
-	function ($rootScope, $scope, $routeParams, playlistService, libraryService,
-			gettext, gettextCatalog, Restangular , $timeout) {
+	'$rootScope', '$scope', 'playlistService', 'libraryService', '$timeout',
+	function ($rootScope, $scope, playlistService, libraryService, $timeout) {
 
 		$scope.tracks = null;
 		$rootScope.currentView = window.location.hash;
@@ -134,10 +132,6 @@ angular.module('Music').controller('AllTracksViewController', [
 		subscribe('artistsLoaded', function () {
 			initViewFromRoute();
 		});
-
-		function listIsPlaying() {
-			return ($rootScope.playingView === $rootScope.currentView);
-		}
 
 		function initViewFromRoute() {
 			if (libraryService.collectionLoaded()) {
@@ -805,7 +799,7 @@ angular.module('Music').controller('PlaylistViewController', [
 	'$rootScope', '$scope', '$routeParams', 'playlistService', 'libraryService',
 	'gettext', 'gettextCatalog', 'Restangular', '$timeout',
 	function ($rootScope, $scope, $routeParams, playlistService, libraryService,
-			gettext, gettextCatalog, Restangular , $timeout) {
+			gettext, gettextCatalog, Restangular, $timeout) {
 
 		var INCREMENTAL_LOAD_STEP = 1000;
 		$scope.incrementalLoadLimit = INCREMENTAL_LOAD_STEP;
@@ -899,7 +893,7 @@ angular.module('Music').controller('PlaylistViewController', [
 		};
 
 		$scope.allowDrop = function(draggable, dstIndex) {
-			return $scope.playlist && draggable.srcIndex != dstIndex;
+			return draggable.srcIndex != dstIndex;
 		};
 
 		$scope.updateHoverStyle = function(dstIndex) {

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -569,9 +569,7 @@ angular.module('Music').controller('OverviewController', [
 			$timeout(showMore);
 		}
 
-		subscribe('artistsLoaded', function() {
-			showMore();
-		});
+		subscribe('artistsLoaded', showMore);
 
 		function showLess() {
 			$scope.incrementalLoadLimit -= INCREMENTAL_LOAD_STEP;
@@ -820,7 +818,7 @@ angular.module('Music').controller('PlaylistViewController', [
 			unsubFuncs.push( $rootScope.$on(event, handler) );
 		}
 
-		$scope.$on('$destroy', function () {
+		$scope.$on('$destroy', function() {
 			_.each(unsubFuncs, function(func) { func(); });
 		});
 
@@ -925,15 +923,9 @@ angular.module('Music').controller('PlaylistViewController', [
 
 		// Init happens either immediately (after making the loading animation visible)
 		// or once both aritsts and playlists have been loaded
-		$timeout(function() {
-			initViewFromRoute();
-		});
-		subscribe('artistsLoaded', function () {
-			initViewFromRoute();
-		});
-		subscribe('playlistsLoaded', function () {
-			initViewFromRoute();
-		});
+		$timeout(initViewFromRoute);
+		subscribe('artistsLoaded', initViewFromRoute);
+		subscribe('playlistsLoaded', initViewFromRoute);
 
 		function listIsPlaying() {
 			return ($rootScope.playingView === $rootScope.currentView);

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -1441,7 +1441,7 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 				});
 
 				if (scope.currentTrack) {
-					var playing = listContainer.querySelector('[data-track-id="' + scope.currentTrack.id + '"]');
+					var playing = listContainer.querySelector('#track-' + scope.currentTrack.id);
 					if (playing) {
 						playing.classList.add('current');
 						if ($rootScope.playing) {
@@ -1499,7 +1499,6 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 				var trackData = getTrackData(track, index, scope);
 				var newElement = trackRenderer(trackData);
 				listItem.id = 'track-' + trackData.id;
-				listItem.setAttribute('data-track-id', trackData.id);
 				listItem.setAttribute('draggable', true);
 				listItem.className = className;
 				listItem.innerHTML = newElement;
@@ -1521,13 +1520,21 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 				listContainer.insertBefore(trackListFragment, toggle[0]);
 			}
 
+			function trackIdFromElementId(elemId) {
+				if (elemId && elemId.substring(0, 6) === 'track-') {
+					return parseInt(elemId.split('-')[1]);
+				} else {
+					return null;
+				}
+			}
+
 			/**
 			 * Click handler for list items
 			 */
 			element.on('click', 'li', function (event) {
-				var trackId = this.getAttribute('data-track-id');
+				var trackId = trackIdFromElementId(this.id);
 				if (trackId) {
-					playTrack(parseInt(trackId));
+					playTrack(trackId);
 					scope.$apply();
 				}
 				else { // "show more/less" item
@@ -1546,7 +1553,7 @@ angular.module('Music').directive('trackList', ['$window', '$rootScope', '$inter
 				if (e.originalEvent) {
 					e.dataTransfer = e.originalEvent.dataTransfer;
 				}
-				var trackId = this.getAttribute('data-track-id');
+				var trackId = trackIdFromElementId(this.id);
 				var offset = {x: e.offsetX, y: e.offsetY};
 				var transferDataObject = {
 					data: getDraggable(trackId),

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -126,11 +126,12 @@ angular.module('Music').controller('AllTracksViewController', [
 
 		// Init happens either immediately (after making the loading animation visible)
 		// or once aritsts have been loaded
-		$timeout(function() {
-			initView();
-		});
+		$timeout(initView);
+
 		subscribe('artistsLoaded', function () {
-			initView();
+			// Nullify any previous tracks to force tracklist directive recreation
+			$scope.tracks = null;
+			$timeout(initView);
 		});
 
 		function initView() {

--- a/js/public/app.js
+++ b/js/public/app.js
@@ -1378,12 +1378,13 @@ angular.module('Music').directive('sidebarListItem', function() {
 });
 
 /**
- * This custom directive produces a self-contained track list widget that updates its list items according to the global playback state and user interaction.
+ * This custom directive produces a self-contained track list widget that updates
+ * its list items according to the global playback state and user interaction.
  * Handling this with markup alone would produce a large amount of watchers.
  */
 
-
-angular.module('Music').directive('trackList', ['$window', '$rootScope', '$interpolate', function ($window, $rootScope, $interpolate) {
+angular.module('Music').directive('trackList', ['$rootScope', '$interpolate',
+function ($rootScope, $interpolate) {
 
 	var tpl = '<div class="play-pause"></div>' +
 		'<span class="muted">{{ number ? number + ".&nbsp;" : "" }}</span>' +

--- a/templates/main.php
+++ b/templates/main.php
@@ -32,6 +32,9 @@
 	<script type="text/ng-template" id="overview.html">
 		<?php print_unescaped($this->inc('partials/overview')) ?>
 	</script>
+	<script type="text/ng-template" id="alltracksview.html">
+		<?php print_unescaped($this->inc('partials/alltracksview')) ?>
+	</script>
 	<script type="text/ng-template" id="playlistview.html">
 		<?php print_unescaped($this->inc('partials/playlistview')) ?>
 	</script>

--- a/templates/partials/alltracksview.php
+++ b/templates/partials/alltracksview.php
@@ -1,0 +1,14 @@
+<div class="playlist-area" id="alltracks-area" ng-show="!loading && !loadingCollection">
+	<h1>
+		<span ng-click="playAll()">
+			<span translate>All tracks</span>
+			<img class="play svg" alt="{{ 'Play' | translate }}" src="<?php p(OCP\Template::image_path('music', 'play-big.svg')) ?>"/>
+		</span>
+	</h1>
+	<track-list ng-if="tracks && !loading && !loadingCollection"
+		tracks="tracks"
+		get-track-data="getTrackData"
+		play-track="playTrack"
+		get-draggable="getDraggable"
+	/>
+</div>

--- a/templates/partials/alltracksview.php
+++ b/templates/partials/alltracksview.php
@@ -5,7 +5,7 @@
 			<img class="play svg" alt="{{ 'Play' | translate }}" src="<?php p(OCP\Template::image_path('music', 'play-big.svg')) ?>"/>
 		</span>
 	</h1>
-	<track-list ng-if="tracks && !loading && !loadingCollection"
+	<track-list ng-if="tracks"
 		tracks="tracks"
 		get-track-data="getTrackData"
 		play-track="playTrack"

--- a/templates/partials/overview.php
+++ b/templates/partials/overview.php
@@ -20,6 +20,10 @@
 				 src="<?php p(OCP\Template::image_path('music', 'play-big.svg')) ?>" />
 			<track-list
 					tracks="album.tracks"
+					get-track-data="getTrackData"
+					play-track="playTrack"
+					get-draggable="getTrackDraggable"
+					collapse-limit="6"
 					more-text="'Show all {{ album.tracks.length }} songs …' | translate"
 					less-text="'Show less …' | translate"
 			/>

--- a/templates/partials/playlistview.php
+++ b/templates/partials/playlistview.php
@@ -1,8 +1,7 @@
 <div class="playlist-area" ng-show="!loading && !loadingCollection">
 	<h1>
 		<span ng-click="playAll()">
-			<span ng-if="playlist">{{ playlist.name }}</span>
-			<span ng-if="currentView == '#/alltracks'" translate>All tracks</span>
+			<span>{{ playlist.name }}</span>
 			<img class="play svg" alt="{{ 'Play' | translate }}" src="<?php p(OCP\Template::image_path('music', 'play-big.svg')) ?>"/>
 		</span>
 	</h1>
@@ -22,13 +21,13 @@
 					<span class="muted">{{ $index + 1 }}.</span>
 					<div bo-text="song.artistName + ' - ' + song.title"></div>
 				</div>
-				<button class="svg action icon-close" ng-click="removeTrack($index)" bo-if="playlist"
+				<button class="svg action icon-close" ng-click="removeTrack($index)"
 					bo-alt="'Remove' | translate" bo-title="'Remove track from playlist' | translate"></button>
 			</div>
 		</li>
 	</ul>
 
-	<div id="emptycontent" ng-show="playlist && playlist.tracks.length == 0 && !scanning && !toScan && !noMusicAvailable">
+	<div id="emptycontent" ng-show="playlist.tracks.length == 0 && !scanning && !toScan && !noMusicAvailable">
 		<div class="icon-audio svg"></div>
 		<h2 translate>No tracks</h2>
 		<p translate>Add tracks with drag and drop from Albums or other playlists</p>


### PR DESCRIPTION
The "All tracks" view has been separated from the "Playlist" view, now having its own controller and php template. The "All tracks" view now utilizes the same custom tracklist directive as the "Albums" view, making it load much faster on large collections. The difference is clearly visible already with 2000 tracks, but more importantly, it makes the "All tracks" view usable also on huge collections (50k+ tracks): E.g. on my tests setup, the time to load "All tracks" view with 58625 tracks was reduced from more than one minute to ~8.5 seconds.

The tracklist directive has been modified a bit to enable using it in different contexts. Mainly, some logic has been moved out from the directive and is now provided by the host controller. These dependencies are injected in the directive initialization.

It would probably be possible to utilize the tracklist directive also with the custom playlists. That, however, would take some more effort because of the more dynamic nature of those lists: it is possible to reorder and remove tracks on the fly on those lists. Anyway, that is outside the scope of this
PR.