### PR TITLE
Russian playlist translation fix

### DIFF
--- a/l10n/ru/music.po
+++ b/l10n/ru/music.po
@@ -23,7 +23,7 @@ msgstr ""
 
 #: ../templates/main.php:60
 msgid "+ New Playlist"
-msgstr "Новый список проигрывания"
+msgstr "Новый плейлист"
 
 #: ../templates/fake-template.php:7 ../templates/main.php:55
 msgid "Albums"


### PR DESCRIPTION
Nobody calls playlist "список проигрывания" in Russia. "плейлист" is a modern word for that.
It's unavailable in transifex so I requested it here.