### PR TITLE
Support year for .m4a

### DIFF
--- a/utility/scanner.php
+++ b/utility/scanner.php
@@ -230,7 +230,7 @@ class Scanner extends PublicEmitter {
 		$meta['discNumber'] = self::normalizeOrdinal($meta['discNumber']);
 
 		// year
-		$meta['year'] = ExtractorGetID3::getFirstOfTags($fileInfo, ['year', 'date']);
+		$meta['year'] = ExtractorGetID3::getFirstOfTags($fileInfo, ['year', 'date', 'creation_date']);
 		$meta['year'] = self::normalizeYear($meta['year']);
 
 		$meta['picture'] = ExtractorGetID3::getTag($fileInfo, 'picture', true);


### PR DESCRIPTION
Adds year support for .m4a files.  
#743 has been fixed upstream, so second commit removed.