### PR TITLE
set user agent when fetching podcasts

### DIFF
--- a/lib/Utility/PodcastService.php
+++ b/lib/Utility/PodcastService.php
@@ -119,7 +119,7 @@ class PodcastService {
 	 * @return array like ['status' => int, 'channel' => ?PodcastChannel]
 	 */
 	public function subscribe(string $url, string $userId) : array {
-		$content = \file_get_contents($url);
+		$content = self::fetchUrl($url);
 		if ($content === false) {
 			return ['status' => self::STATUS_INVALID_URL, 'channel' => null];
 		}
@@ -180,7 +180,7 @@ class PodcastService {
 
 		if ($channel !== null) {
 			$xmlTree = null;
-			$content = \file_get_contents($channel->getRssUrl());
+			$content = self::fetchUrl($channel->getRssUrl());
 			if ($content === null) {
 				$status = self::STATUS_INVALID_URL;
 			} else {
@@ -263,4 +263,18 @@ class PodcastService {
 		return $episodes;
 	}
 
+	/**
+	 * @param string $url
+	 * @return string|false
+	 */
+	private static function fetchUrl(string $url) {
+		// some podcast services require a valid user agent to be set
+		$opts = [
+			"http" => [
+				"header" => "User-Agent: PodcastService"
+			]
+		];
+		$context = stream_context_create($opts);
+		return \file_get_contents($url, false, $context);
+	}
 }


### PR DESCRIPTION
Requests without valid user agents are blocked by some cdn services.

Currently trying to add "https://feeds.acast.com/public/shows/6046295bba4c4c35b8b757cb" (and I assume any other podcast hosted on the same platform) will result in an "Invalid url" error.

(Thanks for adding the podcasting feature, I was just looking for a good way to listen to them when the update was released :heart: )