### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/js/app/controllers/searchcontroller.js
+++ b/js/app/controllers/searchcontroller.js
@@ -127,7 +127,7 @@ function ($scope, $rootScope, libraryService, $timeout, $document, gettextCatalo
 		} else if (view == '#/podcasts') {
 			matchingTracks = searchInPodcastsView(query);
 		} else if (view.startsWith('#/playlist/')) {
-			matchingTracks = searchInPlaylistView(view.substr('#/playlist/'.length), query);
+			matchingTracks = searchInPlaylistView(view.slice('#/playlist/'.length), query);
 		} else {
 			OC.Notification.showTemporary(gettextCatalog.getString('Search not available in this view'));
 			endProgress();

--- a/js/app/controllers/views/albumsviewcontroller.js
+++ b/js/app/controllers/views/albumsviewcontroller.js
@@ -261,7 +261,7 @@ angular.module('Music').controller('AlbumsViewController', [
 		subscribe('albumsLayoutChanged', updateColumnLayout);
 
 		function initializePlayerStateFromURL() {
-			var hashParts = window.location.hash.substr(1).split('/');
+			var hashParts = window.location.hash.slice(1).split('/');
 			if (!hashParts[0] && hashParts[1] && hashParts[2]) {
 				var type = hashParts[1];
 				var id = hashParts[2].split('?')[0]; // crop any query part

--- a/js/app/services/alphabetindexingservice.js
+++ b/js/app/services/alphabetindexingservice.js
@@ -27,7 +27,7 @@ angular.module('Music').service('alphabetIndexingService', [function() {
 		},
 
 		titlePrecedesIndexCharAt: function(title, charIdx) {
-			var initialChar = title.substr(0,1).toUpperCase();
+			var initialChar = title.slice(0,1).toUpperCase();
 
 			// Special case: '…' is considered to be larger than Z or any of its variants
 			// but equal to any other character greater than Z


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.