### PR TITLE
Updates the regexp used to parse a podcast's episode's duration

### DIFF
--- a/lib/BusinessLayer/PodcastEpisodeBusinessLayer.php
+++ b/lib/BusinessLayer/PodcastEpisodeBusinessLayer.php
@@ -132,8 +132,8 @@ class PodcastEpisodeBusinessLayer extends BusinessLayer {
 
 		if (\ctype_digit($data)) {
 			return (int)$data; // plain seconds
-		} elseif (\preg_match('/^(\d\d):(\d\d):(\d\d).*/', $data, $matches) === 1) {
-			return (int)$matches[1] * 3600 + (int)$matches[2] * 60 + (int)$matches[3]; // HH:MM:SS
+		} elseif (\preg_match('/^(?:(?:(?<hours>\d+):)?(?<minutes>[0-5]?\d):)?(?<seconds>[0-5]\d)(?:\.\d*)?$/', $data, $matches) === 1) {
+			return (int)$matches['hours'] * 3600 + (int)$matches['minutes'] * 60 + (int)$matches['seconds']; // HH:MM:SS
 		} else {
 			return null; // no value or unsupported format
 		}


### PR DESCRIPTION
The updated regular expressions supports the following duration formats:

* HH:MM:SS
* HH:MM:SS.sss
* MM:SS
* MM:SS.sss
* SS
* SS.sss

Accepted values:

* HH: 0 -> infinite. As we calculate a duration, the number of hours is not limited
* MM: 0 -> 59 (Both 00, 01,... and 0, 1,... are recognized)
* SS: 0 -> 59 (Both 00, 01,... and 0, 1,... are recognized)

If the subsecond part is present, it is neglected when caculating the episode's duration.

Resolves owncloud/music#967