### PR TITLE
Implemented a "timestamp preview" for the seek bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
   * Ctrl + Arrow Left/Right: Skip previous/next
   * Step size of seeking and volume control is increased when shift held down
 - 'Skip previous' shown in the play/pause context menu on narrow screens where it doesn't fit in the controls pane
+- Preview of the seek position shown while hovering over the seek bar
+  [#1007](https://github.com/owncloud/music/pull/1007) @Root-Core
 
 ### Changed
 - Use background color definitions from the cloud core when available. Fixes a problem with the Nextcloud Breeze Dark theme introduced in v1.6.0.

--- a/css/embedded/files-music-player.css
+++ b/css/embedded/files-music-player.css
@@ -254,6 +254,10 @@
 	background-color: #1d2d44;
 }
 
+#music-controls .translucent {
+	opacity: 0.75;
+}
+
 #music-controls .buffer-bar {
 	opacity: 0.1;
 }
@@ -408,6 +412,10 @@ body.snapjs-left #music-controls {
 
 #music-controls.dark-theme .svg {
 	filter: invert(100%);
+}
+
+#music-controls.dark-theme .translucent {
+	opacity: 0.9;
 }
 
 .musicPlaylistTabView.dark-theme ol li:hover,

--- a/css/music-controls.css
+++ b/css/music-controls.css
@@ -173,6 +173,10 @@ body:not(.snapjs-left) #controls.taller-header {
 	background-color: #1d2d44;
 }
 
+.translucent {
+	opacity: 0.75;
+}
+
 #controls .buffer-bar {
 	opacity: 0.1;
 }

--- a/css/music-dark-theme.css
+++ b/css/music-dark-theme.css
@@ -34,6 +34,10 @@
 	background-color: rgba(255, 255, 255, 0.1);
 }
 
+.dark-theme .translucent {
+	opacity: 0.9;
+}
+
 .dark-theme .icon-reload {
 	background-image: url(../img/reload-inverted.svg);
 }

--- a/js/app/controllers/playercontroller.js
+++ b/js/app/controllers/playercontroller.js
@@ -28,6 +28,7 @@ function ($scope, $rootScope, playlistService, Audio, gettextCatalog, Restangula
 	$scope.position = {
 		bufferPercent: '0%',
 		currentPercent: '0%',
+		currentPreview: null,
 		current: 0,
 		total: 0
 	};
@@ -519,6 +520,20 @@ function ($scope, $rootScope, playlistService, Audio, gettextCatalog, Restangula
 				setCurrentTrack(track);
 			}
 		}
+	};
+
+	$scope.seekbarPreview = function($event) {
+		if (!$scope.player.seekingSupported()) return;
+
+		var offsetX = $event.offsetX || $event.originalEvent.layerX;
+		var ratio = offsetX / $event.currentTarget.clientWidth;
+		var timestamp = ratio * $scope.position.total;
+		
+		$scope.position.currentPreview = timestamp;
+	};
+
+	$scope.seekbarLeave = function() {
+		$scope.position.currentPreview = null;
 	};
 
 	$scope.seekOffset = function(offset) {

--- a/js/app/controllers/playercontroller.js
+++ b/js/app/controllers/playercontroller.js
@@ -29,6 +29,7 @@ function ($scope, $rootScope, playlistService, Audio, gettextCatalog, Restangula
 		bufferPercent: '0%',
 		currentPercent: '0%',
 		currentPreview: null,
+		currentPreview_ts: null,
 		current: 0,
 		total: 0
 	};
@@ -108,6 +109,14 @@ function ($scope, $rootScope, playlistService, Audio, gettextCatalog, Restangula
 						onEnd();
 					}
 				}
+			}
+		}
+
+		// Show progress again instead of preview after a timeout of 1000ms
+		if ($scope.position.currentPreview_ts) {
+			var timeSincePreview = Date.now() - $scope.position.currentPreview_ts;
+			if (timeSincePreview >= 1000) {
+				$scope.seekbarLeave();
 			}
 		}
 	});
@@ -335,6 +344,7 @@ function ($scope, $rootScope, playlistService, Audio, gettextCatalog, Restangula
 			$scope.position.current = 0;
 			$scope.position.currentPercent = 0;
 			$scope.position.currentPreview = null;
+			$scope.position.currentPreview_ts = null;
 			$scope.position.bufferPercent = 0;
 			$scope.position.total = 0;
 		}
@@ -532,10 +542,12 @@ function ($scope, $rootScope, playlistService, Audio, gettextCatalog, Restangula
 		var timestamp = ratio * $scope.position.total;
 		
 		$scope.position.currentPreview = timestamp;
+		$scope.position.currentPreview_ts = Date.now();
 	};
 
 	$scope.seekbarLeave = function() {
 		$scope.position.currentPreview = null;
+		$scope.position.currentPreview_ts = null;
 	};
 
 	// Seekbar preview touch support

--- a/js/app/controllers/playercontroller.js
+++ b/js/app/controllers/playercontroller.js
@@ -29,7 +29,8 @@ function ($scope, $rootScope, playlistService, Audio, gettextCatalog, Restangula
 		bufferPercent: '0%',
 		currentPercent: '0%',
 		currentPreview: null,
-		currentPreview_ts: null,
+		currentPreview_ts: null, // Activation time stamp (Type: Date)
+		currentPreview_tf: null, // Transient mouse movement filter (Type: Number/Timer-Handle)
 		current: 0,
 		total: 0
 	};
@@ -112,10 +113,10 @@ function ($scope, $rootScope, playlistService, Audio, gettextCatalog, Restangula
 			}
 		}
 
-		// Show progress again instead of preview after a timeout of 1000ms
+		// Show progress again instead of preview after a timeout of 2000ms
 		if ($scope.position.currentPreview_ts) {
 			var timeSincePreview = Date.now() - $scope.position.currentPreview_ts;
-			if (timeSincePreview >= 1000) {
+			if (timeSincePreview >= 2000) {
 				$scope.seekbarLeave();
 			}
 		}
@@ -345,6 +346,7 @@ function ($scope, $rootScope, playlistService, Audio, gettextCatalog, Restangula
 			$scope.position.currentPercent = 0;
 			$scope.position.currentPreview = null;
 			$scope.position.currentPreview_ts = null;
+			$scope.position.currentPreview_tf = null;
 			$scope.position.bufferPercent = 0;
 			$scope.position.total = 0;
 		}
@@ -543,6 +545,16 @@ function ($scope, $rootScope, playlistService, Audio, gettextCatalog, Restangula
 		
 		$scope.position.currentPreview = timestamp;
 		$scope.position.currentPreview_ts = Date.now();
+	};
+
+	$scope.seekbarEnter = function() {
+		// Simple filter for transient mouse movements
+		$scope.position.currentPreview_tf = setTimeout(function() {
+			// Force AngularJS to refresh/render scope
+			$scope.$apply(function() {
+				$scope.position.currentPreview_tf = null;
+			});			
+		}, 100);
 	};
 
 	$scope.seekbarLeave = function() {

--- a/js/embedded/embeddedplayer.js
+++ b/js/embedded/embeddedplayer.js
@@ -230,9 +230,11 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 
 		var seekBar = $(document.createElement('div')).attr('class', 'seek-bar');
 		var playBar = $(document.createElement('div')).attr('class', 'play-bar');
+		var transBar = $(document.createElement('div')).attr('class', 'play-bar translucent');
 		var bufferBar = $(document.createElement('div')).attr('class', 'buffer-bar');
 
 		seekBar.append(playBar);
+		seekBar.append(transBar);
 		seekBar.append(bufferBar);
 
 		var loadingText = $(document.createElement('span')).attr('class', 'progress-text').text(t('music', 'Loading…')).hide();
@@ -246,6 +248,7 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 
 		function updateProgress() {
 			var ratio = 0;
+			var previewRatio = null;
 			if ($.isNumeric(songLength_s)) {
 				// Filter transient mouse movements
 				var preview = playTimePreview_tf ? null : playTimePreview_s;
@@ -259,12 +262,22 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 					var timeSincePreview = Date.now() - playTimePreview_ts;
 					if (timeSincePreview >= 2000) {
 						seekSetPreview(null);
+					} else {
+						previewRatio = preview / songLength_s;
 					}
 				}
 			} else {
 				text.text(fmt(playTime_s));
 			}
-			playBar.css('width', 100 * ratio + '%');
+
+			if (previewRatio === null) {
+				playBar.css('width', 100 * ratio + '%');
+				transBar.css('width', '0');
+			} else {
+				playBar.css('width', Math.min(ratio, previewRatio) * 100 + '%');
+				transBar.css('left', Math.min(ratio, previewRatio) * 100 + '%');
+				transBar.css('width', Math.abs(ratio - previewRatio) * 100 + '%');
+			}
 		}
 
 		function setCursorType(type) {
@@ -358,7 +371,7 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 				updateProgress();
 			}, 100);
 		});
-		seekBar.mouseout(function() {
+		seekBar.mouseleave(function() {
 			seekSetPreview(null);
 			text_playTime.css('font-style', 'normal');
 		});

--- a/js/embedded/embeddedplayer.js
+++ b/js/embedded/embeddedplayer.js
@@ -30,6 +30,7 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 	var nextPrevEnabled = false;
 	var playDelayTimer = null;
 	var currentFileId = null;
+	var playTimePreview_ts = null;
 	var playTimePreview_s = null;
 	var playTime_s = 0;
 
@@ -248,6 +249,14 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 				text_playTime.text(fmt(playTimePreview_s || playTime_s));
 				text_playTime.css('font-style', playTimePreview_s ? 'italic' : 'normal');
 				ratio = playTime_s / songLength_s;
+
+				// Show progress again instead of preview after a timeout of 1000ms
+				if (playTimePreview_ts) {
+					var timeSincePreview = Date.now() - playTimePreview_ts;
+					if (timeSincePreview >= 1000) {
+						seekSetPreview(null);
+					}
+				}
 			} else {
 				text.text(fmt(playTime_s));
 			}
@@ -271,6 +280,7 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 		}
 
 		player.on('loading', function() {
+			playTimePreview_ts = null;
 			playTimePreview_s = null;
 			playTime_s = 0;
 			songLength_s = 0;
@@ -317,6 +327,7 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 			return percentage * player.getDuration();
 		}
 		function seekSetPreview(value) {
+			playTimePreview_ts = value ? Date.now() : null;
 			playTimePreview_s = value;
 
 			// manually update is necessary if player is not progressing

--- a/js/embedded/embeddedplayer.js
+++ b/js/embedded/embeddedplayer.js
@@ -326,13 +326,38 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 		seekBar.click(function (event) {
 			var percentage = seekPositionPercentage(event);
 			player.seek(percentage);
+			seekSetPreview(null); // Reset seek preview
 		});
+
+		// Seekbar preview mouse support
 		seekBar.mousemove(function(event) {
 			if (player.seekingSupported()) {
 				seekSetPreview(seekPositionTotal(event) / 1000);
 			}
 		});
 		seekBar.mouseout(function() {
+			seekSetPreview(null);
+			text_playTime.css('font-style', 'normal');
+		});
+
+		// Seekbar preview touch support
+		seekBar.bind('touchmove', function($event) {
+			if (!player.seekingSupported()) return;
+
+			var rect = $event.target.getBoundingClientRect();
+			var x = $event.targetTouches[0].clientX - rect.x;
+			var offsetX = Math.min(Math.max(0, x), rect.width);
+			var ratio = offsetX / rect.width;
+
+			seekSetPreview(ratio * songLength_s);
+		});
+
+		seekBar.bind('touchend', function($event) {
+			if (!player.seekingSupported() || $event?.type !== 'touchend') return;
+			
+			// Reverse calculate on seek position
+			player.seek(playTimePreview_s / songLength_s);
+			
 			seekSetPreview(null);
 			text_playTime.css('font-style', 'normal');
 		});

--- a/js/embedded/embeddedplayer.js
+++ b/js/embedded/embeddedplayer.js
@@ -266,8 +266,13 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 						previewRatio = preview / songLength_s;
 					}
 				}
+
+				text_seperator.show();
+				text_songLength.show();
 			} else {
-				text.text(fmt(playTime_s));
+				text_playTime.text(fmt(playTime_s));
+				text_seperator.hide();
+				text_songLength.hide();
 			}
 
 			if (previewRatio === null) {

--- a/js/embedded/embeddedplayer.js
+++ b/js/embedded/embeddedplayer.js
@@ -253,8 +253,8 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 				// Filter transient mouse movements
 				var preview = playTimePreview_tf ? null : playTimePreview_s;
 
-				text_playTime.text(fmt(preview || playTime_s));
-				text_playTime.css('font-style', preview ? 'italic' : 'normal');
+				text_playTime.text(fmt(preview ?? playTime_s));
+				text_playTime.css('font-style', (preview !== null) ? 'italic' : 'normal');
 				ratio = playTime_s / songLength_s;
 
 				// Show progress again instead of preview after a timeout of 2000ms
@@ -350,7 +350,7 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 			return percentage * player.getDuration();
 		}
 		function seekSetPreview(value) {
-			playTimePreview_ts = value ? Date.now() : null;
+			playTimePreview_ts = (value !== null) ? Date.now() : null;
 			playTimePreview_s = value;
 
 			// manually update is necessary if player is not progressing

--- a/js/embedded/embeddedplayer.js
+++ b/js/embedded/embeddedplayer.js
@@ -319,10 +319,9 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 		function seekSetPreview(value) {
 			playTimePreview_s = value;
 
-			// manually update, if player is not progressing
-			if (!player.isPlaying()) {
-				updateProgress();
-			}
+			// manually update is necessary if player is not progressing
+			// it also feels choppy if we rely on the progress event only
+			updateProgress();
 		}
 		seekBar.click(function (event) {
 			var percentage = seekPositionPercentage(event);

--- a/js/shared/gaplessplayer.js
+++ b/js/shared/gaplessplayer.js
@@ -80,6 +80,18 @@ OCA.Music.GaplessPlayer = function() {
 		return m_currentPlayer.canPlayMime(mime);
 	};
 
+	this.isReady = function() {
+		return m_currentPlayer.isReady();
+	};
+
+	this.getDuration = function() {
+		return m_currentPlayer.getDuration();
+	};
+
+	this.getBufferPercent = function() {
+		return m_currentPlayer.getBufferPercent();
+	};
+
 	this.getUrl = function() {
 		return m_currentPlayer.getUrl();
 	};

--- a/templates/partials/controls.php
+++ b/templates/partials/controls.php
@@ -8,13 +8,13 @@
 			title="{{ playPauseContextMenuVisible ? null : ('press and hold for more' | translate) }}"
 			ng-on-contextmenu="playbackBtnContextMenu($event)"
 			ng-on-long-press="playbackBtnLongPress($event)"
-			data-long-press-delay="500" 
+			data-long-press-delay="500"
 		>
 			<div id="stop-button" ng-click="stop()" class="control icon-stop svg"
 				ng-show="shiftHeldDown" alt="{{ 'Stop' | translate }}">
 			</div>
 			<div id="play-pause-button" ng-click="togglePlayback()" class="control svg"
-				ng-class="playing ? 'icon-pause-big' : 'icon-play-big'" 
+				ng-class="playing ? 'icon-pause-big' : 'icon-play-big'"
 				ng-show="!shiftHeldDown" alt="{{ (playing ? 'Pause' : 'Play') | translate }}">
 			</div>
 			<div id="play-pause-menu" class="popovermenu bubble" ng-show="playPauseContextMenuVisible">
@@ -61,20 +61,25 @@
 	</div>
 	<div ng-show="currentTrack" class="progress-info">
 		<div class="progress-text">
-			<span ng-show="!loading" class="muted" ng-style="position.currentPreview && !position.currentPreview_tf && {'font-style': 'italic'}">
-				{{ ((position.currentPreview_tf ? null : position.currentPreview) || position.current) | playTime }}
+			<span ng-show="!loading" class="muted" ng-style="position.previewVisible() && {'font-style': 'italic'}">
+				{{ (position.previewVisible() ? position.currentPreview : position.current) | playTime }}
 			</span>
 			<span ng-show="!loading && durationKnown()" class="muted">/ {{ position.total | playTime }}</span>
 			<span ng-show="loading" class="muted">Loading...</span>
 		</div>
 		<div class="progress">
 			<div class="seek-bar" ng-style="{'cursor': seekCursorType}"
-				ng-click="seek($event)" ng-mousemove="seekbarPreview($event)" ng-mouseenter="seekbarEnter($event)" ng-mouseout="seekbarLeave()"
+				ng-click="seek($event)" ng-mousemove="seekbarPreview($event)" ng-mouseenter="seekbarEnter($event)" ng-mouseleave="seekbarLeave($event)"
 				ng-touchmove="seekbarTouchPreview($event)" ng-touchend="seekbarTouchLeave($event)"
 			>
-				<div class="buffer-bar" ng-style="{'width': position.bufferPercent, 'cursor': seekCursorType}"></div>
+				<div class="buffer-bar" ng-style="{'width': position.bufferPercent + '%', 'cursor': seekCursorType}"></div>
 				<div class="play-bar" ng-show="position.total"
-					ng-style="{'width': position.currentPercent, 'cursor': seekCursorType}"></div>
+					ng-style="{'width': (position.previewVisible() ? min(position.currentPercent, position.previewPercent) : position.currentPercent) + '%',
+								'cursor': seekCursorType}"></div>
+				<div class="play-bar translucent" ng-show="position.total && position.previewVisible()"
+					ng-style="{'width': abs(position.currentPercent - position.previewPercent) + '%',
+								'left': min(position.currentPercent, position.previewPercent) + '%',
+								'cursor': seekCursorType}"></div>
 			</div>
 		</div>
 	</div>

--- a/templates/partials/controls.php
+++ b/templates/partials/controls.php
@@ -70,7 +70,7 @@
 		<div class="progress">
 			<div class="seek-bar" ng-style="{'cursor': seekCursorType}"
 				ng-click="seek($event)" ng-mousemove="seekbarPreview($event)" ng-mouseenter="seekbarEnter($event)" ng-mouseleave="seekbarLeave($event)"
-				ng-touchmove="seekbarTouchPreview($event)" ng-touchend="seekbarTouchLeave($event)"
+				ng-on-touchmove="seekbarTouchPreview($event)" ng-on-touchend="seekbarTouchLeave($event)"
 			>
 				<div class="buffer-bar" ng-style="{'width': position.bufferPercent + '%', 'cursor': seekCursorType}"></div>
 				<div class="play-bar" ng-show="position.total"

--- a/templates/partials/controls.php
+++ b/templates/partials/controls.php
@@ -61,15 +61,15 @@
 	</div>
 	<div ng-show="currentTrack" class="progress-info">
 		<div class="progress-text">
-			<span ng-show="!loading" class="muted" ng-style="position.currentPreview && {'font-style': 'italic'}">
-				{{ (position.currentPreview || position.current) | playTime }}
+			<span ng-show="!loading" class="muted" ng-style="position.currentPreview && !position.currentPreview_tf && {'font-style': 'italic'}">
+				{{ ((position.currentPreview_tf ? null : position.currentPreview) || position.current) | playTime }}
 			</span>
 			<span ng-show="!loading && durationKnown()" class="muted">/ {{ position.total | playTime }}</span>
 			<span ng-show="loading" class="muted">Loading...</span>
 		</div>
 		<div class="progress">
 			<div class="seek-bar" ng-style="{'cursor': seekCursorType}"
-				ng-click="seek($event)" ng-mousemove="seekbarPreview($event)" ng-mouseout="seekbarLeave()"
+				ng-click="seek($event)" ng-mousemove="seekbarPreview($event)" ng-mouseenter="seekbarEnter($event)" ng-mouseout="seekbarLeave()"
 				ng-touchmove="seekbarTouchPreview($event)" ng-touchend="seekbarTouchLeave($event)"
 			>
 				<div class="buffer-bar" ng-style="{'width': position.bufferPercent, 'cursor': seekCursorType}"></div>

--- a/templates/partials/controls.php
+++ b/templates/partials/controls.php
@@ -68,7 +68,10 @@
 			<span ng-show="loading" class="muted">Loading...</span>
 		</div>
 		<div class="progress">
-			<div class="seek-bar" ng-click="seek($event)" ng-mousemove="seekbarPreview($event)" ng-mouseout="seekbarLeave()" ng-style="{'cursor': seekCursorType}">
+			<div class="seek-bar" ng-style="{'cursor': seekCursorType}"
+				ng-click="seek($event)" ng-mousemove="seekbarPreview($event)" ng-mouseout="seekbarLeave()"
+				ng-touchmove="seekbarTouchPreview($event)" ng-touchend="seekbarTouchLeave($event)"
+			>
 				<div class="buffer-bar" ng-style="{'width': position.bufferPercent, 'cursor': seekCursorType}"></div>
 				<div class="play-bar" ng-show="position.total"
 					ng-style="{'width': position.currentPercent, 'cursor': seekCursorType}"></div>

--- a/templates/partials/controls.php
+++ b/templates/partials/controls.php
@@ -61,12 +61,14 @@
 	</div>
 	<div ng-show="currentTrack" class="progress-info">
 		<div class="progress-text">
-			<span ng-show="!loading" class="muted">{{ position.current | playTime }}</span><span
-				ng-show="!loading && durationKnown()" class="muted">/{{ position.total | playTime }}</span>
+			<span ng-show="!loading" class="muted" ng-style="position.currentPreview && {'font-style': 'italic'}">
+				{{ (position.currentPreview || position.current) | playTime }}
+			</span>
+			<span ng-show="!loading && durationKnown()" class="muted">/ {{ position.total | playTime }}</span>
 			<span ng-show="loading" class="muted">Loading...</span>
 		</div>
 		<div class="progress">
-			<div class="seek-bar" ng-click="seek($event)" ng-style="{'cursor': seekCursorType}">
+			<div class="seek-bar" ng-click="seek($event)" ng-mousemove="seekbarPreview($event)" ng-mouseout="seekbarLeave()" ng-style="{'cursor': seekCursorType}">
 				<div class="buffer-bar" ng-style="{'width': position.bufferPercent, 'cursor': seekCursorType}"></div>
 				<div class="play-bar" ng-show="position.total"
 					ng-style="{'width': position.currentPercent, 'cursor': seekCursorType}"></div>


### PR DESCRIPTION
The timestamp that a click on the seek bar would set is shown in advance. This makes it easier to navigate in (not only) bigger files.

I also implemented touch support, which makes using the seekbar with touch way easier imho.
I have tested the touch part on a Microsoft Surface only yet, but it seems fine.

Mouse only: The preview is hidden after 1000ms while a track is played back or if the mouse moves out of the seek bar.

The feature is implemented into the normal player and in the file-plugin one.