### PR TITLE
Add nop getNowPlaying route for SubsonicController

### DIFF
--- a/lib/Controller/SubsonicController.php
+++ b/lib/Controller/SubsonicController.php
@@ -992,7 +992,7 @@ class SubsonicController extends Controller {
 	 */
 	protected function getNowPlaying() {
 		// TODO: not supported yet
-		return $this->subsonicResponse(['nowPlaying' => []]);
+		return $this->subsonicResponse(['nowPlaying' => ['entry' => []]]);
 	}
 
 	/* -------------------------------------------------------------------------

--- a/lib/Controller/SubsonicController.php
+++ b/lib/Controller/SubsonicController.php
@@ -987,6 +987,14 @@ class SubsonicController extends Controller {
 		]]);
 	}
 
+	/**
+	 * @SubsonicAPI
+	 */
+	protected function getNowPlaying() {
+		// TODO: not supported yet
+		return $this->subsonicResponse(['nowPlaying' => []]);
+	}
+
 	/* -------------------------------------------------------------------------
 	 * Helper methods
 	 *------------------------------------------------------------------------*/


### PR DESCRIPTION
Subsonic clients call this API to see what media users are playing. If a client calls this, returning an empty list is better than an a 404 or code 70 for non-supported route, since what a server may return for unimplemented API routes may vary.

Ideally, this should be expanded to actually return what's actually playing on the server.

For an example of an affected client, see SubmarinerApp/Submariner#148.