### PR TITLE
Compatibility for Nextcloud 28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Updated the getID3 library to the development version 1.9.23-202312292105
   * Fixes the issue of garbage bytes being extracted from some RIFF tags
     [#1115](https://github.com/owncloud/music/issues/1115)
+- Search within the Music app now works with an own input field in the navigation pane instead of the unified search input
 
 ### Fixed
 - Songs with scanned integer property value (like track number) larger than 2147483647 causing error on PostgreSQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
 ### Added
+- Support for Nextcloud 28
+  [#1116](https://github.com/owncloud/music/pull/1116)
 - Ampache API: 
   * Support for argument `random` in the method `playlist_songs`
   * Method `bookmark`

--- a/appinfo/app.php
+++ b/appinfo/app.php
@@ -93,7 +93,7 @@ function loadEmbeddedMusicPlayer() {
 }
 
 function isFilesUrl($url) {
-	return \preg_match('%/apps/files/?$%', $url);
+	return \preg_match('%/apps/files/?$%', $url) || \preg_match('%/apps/files/files(/\d*)?$%', $url);
 }
 
 function isShareUrl($url) {

--- a/css/embedded/files-music-mobile-tablet.css
+++ b/css/embedded/files-music-mobile-tablet.css
@@ -5,14 +5,14 @@
  * later. See the COPYING file.
  *
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
- * @copyright Pauli Järvinen 2023
+ * @copyright Pauli Järvinen 2023, 2024
  */
 
  /* "Tablet" style */
 #music-controls.tablet {
 	padding: 0;
 }
-#music-controls.tablet #albumart {
+#music-controls.tablet #albumart-container {
 	margin-left: 10px;
 }
 #music-controls.tablet #info-and-progress {
@@ -30,7 +30,7 @@
 #music-controls.mobile .control {
 	margin-right: 0;
 }
-#music-controls.mobile #albumart {
+#music-controls.mobile #albumart-container {
 	margin-left: 0;
 	margin-right: 0;
 }

--- a/css/embedded/files-music-player.css
+++ b/css/embedded/files-music-player.css
@@ -74,6 +74,7 @@
 	border: none;
 	background-color: transparent;
 	vertical-align: top;
+	min-height: 18px;
 	margin-top: 8px;
 	opacity: .4;
 }

--- a/css/embedded/files-music-player.css
+++ b/css/embedded/files-music-player.css
@@ -5,7 +5,7 @@
  * later. See the COPYING file.
  *
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
- * @copyright Pauli Järvinen 2017 - 2023
+ * @copyright Pauli Järvinen 2017 - 2024
  */
 
 .icon-music-dark {
@@ -127,12 +127,17 @@
 	filter: var(--background-invert-if-dark);
 }
 
-#music-controls #albumart {
-	height: 50px;
+#music-controls #albumart-container {
+	position: relative;
 	width: 50px;
+	height: 50px;
 	margin: 8px 12px 8px 20px;
-	line-height: 50px;
-	font-size: 28px;
+}
+
+#music-controls #albumart {
+	position: absolute;
+	height: 100%;
+	width: 100%;
 	background-size: cover;
 	background-position: center;
 	display: inline-block;
@@ -141,6 +146,10 @@
 
 .ie #music-controls #albumart {
 	border-color: #ededed;
+}
+
+#music-controls #albumart-container.icon-loading #albumart {
+	opacity: 0.2;
 }
 
 #music-controls #info-and-progress {

--- a/css/embedded/files-music-popover-menu.css
+++ b/css/embedded/files-music-popover-menu.css
@@ -24,16 +24,18 @@
 
 #music-controls #playlist-area .popovermenu ul {
 	display: block;
+	padding: 4px;
 }
 
 #music-controls #playlist-area .popovermenu ul li {
-	padding: 0 10px 0 0;
+	padding: 0;
 	white-space: nowrap;
 }
 
 #music-controls #playlist-area .popovermenu ul a {
 	opacity: .7;
 	line-height: 36px;
+	padding-right: 10px;
 }
 
 #music-controls #playlist-area .popovermenu ul a:hover {

--- a/css/music-navigation.css
+++ b/css/music-navigation.css
@@ -11,7 +11,7 @@
  */
 
 .app-music #app-navigation {
-	padding-bottom: calc(44px + var(--body-container-margin, 0px)) !important;
+	padding-bottom: calc(88px + var(--body-container-margin, 0px) + 2 * var(--default-grid-baseline, 0px)) !important;
 	z-index: 999;
 	overflow: unset;
 }
@@ -61,6 +61,7 @@
 
 #app-navigation .music-navigation-item-content {
 	padding-left: 0 !important;
+	height: 44px;
 	line-height: 44px;
 	width: 100%;
 	overflow: hidden;
@@ -73,8 +74,32 @@
 	cursor: pointer;
 }
 
+#app-navigation .music-navigation-item-content > * {
+	display: inline-block;
+	height: 44px;
+}
+
 #app-navigation .music-navigation-item:not(:hover):not(.active):not(.menu-open) .music-navigation-item-content {
 	opacity: 0.7;
+}
+
+#app-navigation .music-navigation-item-content [class^="icon-"] {
+	width: 40px;
+	height: 44px;
+	cursor: pointer;
+}
+
+#app-navigation .music-navigation-item-content:not(:hover) [class^="icon-"] {
+	opacity: 0.7;
+}
+
+#app-navigation .music-navigation-item-content .label {
+	padding-left: 4px;
+	box-shadow: unset;
+	position: absolute;
+	width: auto;
+	right: 0;
+	left: 40px;
 }
 
 #app-navigation-toggle {
@@ -118,25 +143,6 @@
 	background-image: url(../img/pause-big.svg)
 }
 
-#app-navigation #new-playlist {
-	height: 44px;
-}
-
-#app-navigation #new-playlist > * {
-	display: inline-block;
-	height: 44px;
-}
-
-#app-navigation #new-playlist .icon-add {
-	width: 40px;
-	height: 44px;
-	cursor: pointer;
-}
-
-#app-navigation #new-playlist:not(:hover) .icon-add {
-	opacity: 0.7;
-}
-
 #app-navigation #new-playlist .track-count-badge {
 	background-color: var(--color-primary, #1d2d44);
 	color: var(--color-primary-text, #fff);
@@ -148,15 +154,6 @@
 	text-align: center;
 	vertical-align: middle;
 	font-size: smaller;
-}
-
-#app-navigation #new-playlist #create {
-	padding-left: 4px;
-	box-shadow: unset;
-	position: absolute;
-	width: auto;
-	right: 0;
-	left: 40px;
 }
 
 #app-navigation li.drag-hover {
@@ -221,14 +218,12 @@
 #app-navigation .input-container {
 	position: absolute;
 	left: 35px;
-	right: 65px;
+	right: 12px;
 	width: auto;
 }
 
 #app-navigation .input-container input {
 	width: 100%;
-	border-top-right-radius: 0;
-	border-bottom-right-radius: 0;
 	margin-left: 0;
 	margin-bottom: 6px;
 	margin-top: 6px;
@@ -238,22 +233,52 @@
 	box-shadow: unset;
 }
 
+#app-navigation .input-container.with-buttons {
+	right: 65px;
+}
+
+#app-navigation .input-container.with-buttons input {
+	border-top-right-radius: 0;
+	border-bottom-right-radius: 0;
+}
+
+#app-navigation .input-container #search-input {
+	padding-right: 32px;
+}
+
+#app-navigation .input-container #clear-search {
+	position: relative;
+	left: -44px;
+	top: -6px;
+	width: 24px;
+	height: 24px;
+	border: none;
+	background-color: transparent;
+}
+
 #app-navigation .icon-checkmark {
 	position: absolute;
 	right: 30px;
 	float: none;
 }
 
-#app-navigation #music-nav-settings {
+#app-navigation > ul > li.docked-navigation-item {
 	position: fixed;
 	width: unset;
-	bottom: 0;
 	left: 0;
 	right: 0;
 	height: 44px;
 	max-width: 300px;
 	margin: var(--body-container-margin);
 	z-index: 140;
+}
+
+#app-navigation #music-nav-search {
+	bottom: calc(44px + var(--default-grid-baseline, 0px))
+}
+
+#app-navigation #music-nav-settings {
+	bottom: 0;
 }
 
 .legacy-layout #app-navigation #music-nav-settings {

--- a/css/music-navigation.css
+++ b/css/music-navigation.css
@@ -25,7 +25,12 @@
 }
 
 #app-navigation > ul > li {
-	border-radius: var(--border-radius-pill);
+	/* The NC server uses --border-radius-pill for this purpose but we don't because that variable is
+	   available also at least on NC17-24 where the overall layout is not a good fit for rounded highlight.
+	   The border-radius-rounded has slightly larger value but that doesn't cause any visual difference
+	   here because the radius already maxes out for line of height 44px with border-radius-pill.
+	*/
+	border-radius: var(--border-radius-rounded);
 }
 
 #app-navigation > ul > li:hover,
@@ -51,7 +56,7 @@
 #app-navigation .music-navigation-item {
 	position: relative;
 	height: 44px;
-	margin-bottom: 4px;
+	margin-bottom: var(--default-grid-baseline);
 }
 
 #app-navigation .music-navigation-item-content {
@@ -268,4 +273,5 @@
 	height: 16px;
 	margin-right: 11px;
 	margin-top: 1.5px;
+	margin-left: 0;
 }

--- a/css/music-navigation.css
+++ b/css/music-navigation.css
@@ -51,6 +51,7 @@
 #app-navigation .music-navigation-item {
 	position: relative;
 	height: 44px;
+	margin-bottom: 4px;
 }
 
 #app-navigation .music-navigation-item-content {

--- a/css/music-navigation.css
+++ b/css/music-navigation.css
@@ -273,16 +273,16 @@
 	z-index: 140;
 }
 
+.legacy-layout #app-navigation > ul > li.docked-navigation-item {
+	max-width: 250px;
+}
+
 #app-navigation #music-nav-search {
 	bottom: calc(44px + var(--default-grid-baseline, 0px))
 }
 
 #app-navigation #music-nav-settings {
 	bottom: 0;
-}
-
-.legacy-layout #app-navigation #music-nav-settings {
-	max-width: 250px;
 }
 
 #app-navigation #music-nav-settings > a {

--- a/css/music-navigation.css
+++ b/css/music-navigation.css
@@ -24,6 +24,19 @@
 	overflow-y: auto;
 }
 
+#app-navigation > ul > li {
+	border-radius: var(--border-radius-pill);
+}
+
+#app-navigation > ul > li:hover,
+#app-navigation > ul > li:focus {
+	background-color: var(--color-background-hover);
+}
+
+#app-navigation > ul > li.active {
+	background-color: var(--color-primary-element-light);
+}
+
 #app-navigation .app-navigation-separator {
 	border-bottom: 1px solid;
 	border-color: var(--color-main-text, #222);

--- a/css/music-navigation.css
+++ b/css/music-navigation.css
@@ -10,10 +10,18 @@
  * @copyright Pauli Järvinen 2016 - 2023
  */
 
-#app-navigation {
+.app-music #app-navigation {
 	padding-bottom: calc(44px + var(--body-container-margin, 0px)) !important;
 	z-index: 999;
-	display: block;
+	overflow: unset;
+}
+
+#app-navigation > ul {
+	height: 100%;
+	padding: calc(var(--default-grid-baseline)*2);
+	padding-bottom: 0;
+	overflow-x: hidden;
+	overflow-y: auto;
 }
 
 #app-navigation .app-navigation-separator {
@@ -28,6 +36,7 @@
 }
 
 #app-navigation .music-navigation-item {
+	position: relative;
 	height: 44px;
 }
 
@@ -90,9 +99,13 @@
 	background-image: url(../img/pause-big.svg)
 }
 
+#app-navigation #new-playlist {
+	height: 44px;
+}
+
 #app-navigation #new-playlist > * {
 	display: inline-block;
-	height: 100%;
+	height: 44px;
 }
 
 #app-navigation #new-playlist .icon-add {
@@ -203,6 +216,7 @@
 	margin-right: 5px;
 	height: 32px;
 	cursor: text;
+	box-shadow: unset;
 }
 
 #app-navigation .icon-checkmark {
@@ -217,6 +231,7 @@
 	bottom: 0;
 	left: 0;
 	right: 0;
+	height: 44px;
 	max-width: 300px;
 	margin: var(--body-container-margin);
 	z-index: 140;
@@ -224,6 +239,13 @@
 
 .legacy-layout #app-navigation #music-nav-settings {
 	max-width: 250px;
+}
+
+#app-navigation #music-nav-settings > a {
+	display: block;
+	padding-left: 14px;
+	padding-right: 12px;
+	line-height: 44px;
 }
 
 #app-navigation #music-nav-settings > a:first-child img {

--- a/css/music-navigation.css
+++ b/css/music-navigation.css
@@ -7,7 +7,7 @@
  * @author Morris Jobke <hey@morrisjobke.de>
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
  * @copyright Morris Jobke 2013, 2014
- * @copyright Pauli Järvinen 2016 - 2023
+ * @copyright Pauli Järvinen 2016 - 2024
  */
 
 .app-music #app-navigation {
@@ -32,6 +32,7 @@
 	*/
 	border-radius: var(--border-radius-rounded);
 	margin-bottom: var(--default-grid-baseline);
+	transition: background-color .2s ease-in-out;
 }
 
 #app-navigation > ul > li:hover,

--- a/css/music-navigation.css
+++ b/css/music-navigation.css
@@ -31,6 +31,7 @@
 	   here because the radius already maxes out for line of height 44px with border-radius-pill.
 	*/
 	border-radius: var(--border-radius-rounded);
+	margin-bottom: var(--default-grid-baseline);
 }
 
 #app-navigation > ul > li:hover,
@@ -56,7 +57,6 @@
 #app-navigation .music-navigation-item {
 	position: relative;
 	height: 44px;
-	margin-bottom: var(--default-grid-baseline);
 }
 
 #app-navigation .music-navigation-item-content {

--- a/css/music-navigation.css
+++ b/css/music-navigation.css
@@ -225,8 +225,8 @@
 #app-navigation .input-container input {
 	width: 100%;
 	margin-left: 0;
-	margin-bottom: 6px;
-	margin-top: 6px;
+	margin-bottom: 4px;
+	margin-top: 4px;
 	margin-right: 5px;
 	height: 32px;
 	cursor: text;
@@ -248,8 +248,9 @@
 
 #app-navigation .input-container #clear-search {
 	position: relative;
-	left: -44px;
-	top: -6px;
+	vertical-align: middle;
+	left: -40px;
+	top: -2px;
 	width: 24px;
 	height: 24px;
 	border: none;

--- a/css/music-navigation.css
+++ b/css/music-navigation.css
@@ -11,7 +11,7 @@
  */
 
 .app-music #app-navigation {
-	padding-bottom: calc(88px + var(--body-container-margin, 0px) + 2 * var(--default-grid-baseline, 0px)) !important;
+	padding-bottom: calc(88px + 4 * var(--default-grid-baseline, 0px)) !important;
 	z-index: 999;
 	overflow: unset;
 }
@@ -269,7 +269,7 @@
 	right: 0;
 	height: 44px;
 	max-width: 300px;
-	margin: var(--body-container-margin);
+	margin: calc(var(--default-grid-baseline, 0px)*2);
 	z-index: 140;
 }
 

--- a/css/music-search.css
+++ b/css/music-search.css
@@ -5,15 +5,8 @@
  * later. See the COPYING file.
  *
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
- * @copyright Pauli Järvinen 2020
+ * @copyright Pauli Järvinen 2020 - 2023
  */
-
-/* Hide the default results div because we have a custom "filter like" search logic */
-.app-music #searchresults {
-	visibility: hidden;
-	position: absolute;
-	height: 0;
-}
 
 /* Only matching items should be shown when the searchmode is active */
 .searchmode .track-list li:not(.matched):not(.placeholder),

--- a/css/music-sidebar.css
+++ b/css/music-sidebar.css
@@ -5,7 +5,7 @@
  * later. See the COPYING file.
  *
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
- * @copyright Pauli Järvinen 2018 - 2023
+ * @copyright Pauli Järvinen 2018 - 2024
  */
 
 #app-sidebar {
@@ -355,14 +355,14 @@
 
 #app-sidebar #smartlist-filters .chosen-choices {
 	background: var(--color-main-background, #fff);
-	border: 2px solid var(--color-border-dark, #ddd);
-	border-radius: var(--border-radius-large);
+	border: var(--border-input);				/* value of the var is set in our javascript */
+	border-radius: var(--border-radius-input);	/* value of the var is set in our javascript */
 	text-overflow: ellipsis;
 	cursor: pointer;
 }
 
 #app-sidebar #smartlist-filters .chosen-choices:hover {
-	border-color: var(--color-primary-element);
+	border-color: var(--color-input-border-hover); /* value of the var is set in our javascript */
 }
 
 #app-sidebar #smartlist-filters .chosen-choices input {

--- a/js/app/controllers/maincontroller.js
+++ b/js/app/controllers/maincontroller.js
@@ -455,8 +455,12 @@ function ($rootScope, $scope, $timeout, $window, ArtistFactory,
 
 	$scope.collapseNavigationPaneOnMobile = function() {
 		if ($('body').hasClass('snapjs-left')) {
-			// There is a fake button within the navigation pane which can be "clicked" to make the core collapse the pane
-			$timeout(() => $('#hidden-close-app-navigation-button').click());
+			$timeout(() => {
+				// There is a fake button within the navigation pane which can be "clicked" to make the core collapse the pane
+				$('#hidden-close-app-navigation-button').trigger('click');
+				// Remove any active input focus to ensure that the focus is not left to an input field within the collapsed pane
+				$(document.activeElement).trigger('blur');
+			});
 		}
 	};
 

--- a/js/app/controllers/navigationcontroller.js
+++ b/js/app/controllers/navigationcontroller.js
@@ -66,6 +66,7 @@ angular.module('Music').controller('NavigationController', [
 			// because the field is not visible yet, it is shown by ng-show binding
 			// later during this digest loop.
 			$timeout(() => $('#search-input').trigger('focus'));
+			expandCollapsedNavigationPane();
 		};
 
 		$scope.clearSearch = function() {
@@ -352,7 +353,7 @@ angular.module('Music').controller('NavigationController', [
 		navToggle.addEventListener('dragenter', function() {
 			if (!navOpenedByDrag) {
 				navOpenedByDrag = true;
-				$timeout(() => $(navToggle).click());
+				expandCollapsedNavigationPane();
 			}
 		});
 		document.addEventListener('dragend', function() {
@@ -361,6 +362,12 @@ angular.module('Music').controller('NavigationController', [
 				$scope.collapseNavigationPaneOnMobile();
 			}
 		});
+
+		function expandCollapsedNavigationPane() {
+			if (!$('body').hasClass('snapjs-left') && $(navToggle).is(':visible')) {
+				$timeout(() => $(navToggle).trigger('click'));
+			}
+		}
 
 		function createPlaylist(name, trackIds) {
 			const args = {

--- a/js/app/controllers/searchcontroller.js
+++ b/js/app/controllers/searchcontroller.js
@@ -5,41 +5,25 @@
  * later. See the COPYING file.
  *
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
- * @copyright Pauli Järvinen 2020, 2021
+ * @copyright Pauli Järvinen 2020 - 2023
  */
 
 /**
  * This controller implements the search/filtering logic for all views. The details
  * of the search still vary per-view.
- * 
- * When the search query is written to the searchbox, the core automatically sends the query
- * to the backend. However, we disregard any results from the back-end and conduct the search
- * on our own, on the front-end.
  */
 angular.module('Music').controller('SearchController', [
-'$scope', '$rootScope', 'libraryService', '$timeout', '$document', 'gettextCatalog',
-function ($scope, $rootScope, libraryService, $timeout, $document, gettextCatalog) {
+'$scope', '$rootScope', 'libraryService', '$timeout', 'gettextCatalog',
+function ($scope, $rootScope, libraryService, $timeout, gettextCatalog) {
 
 	const MAX_MATCHES = 5000;
 	const MAX_MATCHES_IN_PLAYLIST = 1000;
 	const MAX_FOLDER_MATCHES_IN_TREE_LAYOUT = 50;
 
-	let searchform = $('.searchbox');
-	let searchbox = $('#searchbox');
+	let searchbox = $('#search-input');
 	let treeFolderMatches = {};
 
-	if (searchbox.length === 0) { // NC 20+
-		$.initialize('.unified-search__form', function(_index, elem) {
-			searchform = $(elem);
-			searchbox = searchform.find('input');
-			init();
-		});
-	}
-	else { // NC < 20 or OC
-		init();
-		// the keyboard shortcut has to be registered manually, on NC20 this is handled by the core
-		registerCtrlF();
-	}
+	init();
 
 	function init() {
 		$scope.queryString = searchbox.val().trim();
@@ -50,33 +34,13 @@ function ($scope, $rootScope, libraryService, $timeout, $document, gettextCatalo
 				onEnterSearchString();
 			}
 		}, 250);
-		searchbox.bind('propertychange change keyup input paste', checkQueryChange);
-
-		/** Handle clearing the searchbox. This has to be registered to the parent form
-		 *  of the #searchbox element.
-		 */
-		searchform.on('reset', function() {
-			$scope.queryString = '';
-			$scope.$apply(startProgress);
-			$timeout(clearSearch);
-		});
+		searchbox.on('propertychange change keyup input paste', checkQueryChange);
 
 		/** Run search when enter pressed within the searchbox */
-		searchbox.bind('keydown', function (event) {
+		searchbox.on('keydown', function (event) {
 			if (event.which === 13) {
 				onEnterSearchString();
 			}
-		});
-	}
-
-	function registerCtrlF() {
-		/** Catch ctrl+f except when the Settings view is active */
-		$document.bind('keydown', function(e) {
-			if ($rootScope.currentView !== '#/settings' && e.ctrlKey && e.key === 'f') {
-				searchbox.focus();
-				return false;
-			}
-			return true;
 		});
 	}
 

--- a/js/app/controllers/sidebar/smartlistfilterscontroller.js
+++ b/js/app/controllers/sidebar/smartlistfilterscontroller.js
@@ -5,7 +5,7 @@
  * later. See the COPYING file.
  *
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
- * @copyright Pauli Järvinen 2023
+ * @copyright Pauli Järvinen 2023, 2024
  */
 
 
@@ -33,7 +33,19 @@ angular.module('Music').controller('SmartListFiltersController', [
 		$timeout(() => {
 			$('#filter-genres').chosen();
 			$('#filter-artists').chosen();
-			$('#app-sidebar #smartlist-filters .chosen-container').css('width', ''); // purge the inline rule to let the CSS define the width
+			const $chosenInputs = $('#app-sidebar #smartlist-filters .chosen-container');
+			const $filterGenres = $('#filter-genres');
+			const $filterSize = $('#filter-size');
+
+			$chosenInputs
+				.css('width', '') // purge the inline rule to let the CSS define the width
+				.css('--border-input', $filterGenres.css('border')) // copy the border style from the input field
+				.css('--border-radius-input', $filterGenres.css('border-radius'));
+
+			$filterSize.trigger('focus');
+			$timeout(() => {
+				$chosenInputs.css('--color-input-border-hover', $filterSize.css('border-color')); // copy the border color of focused input
+			});
 		});
 
 		function allFieldsValid() {

--- a/js/app/directives/onesc.js
+++ b/js/app/directives/onesc.js
@@ -4,18 +4,16 @@
  * This file is licensed under the Affero General Public License version 3 or
  * later. See the COPYING file.
  *
- * @author Volkan Gezer <volkangezer@gmail.com>
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
- * @copyright 2014 Volkan Gezer
- * @copyright 2020 - 2023 Pauli Järvinen
+ * @copyright 2023 Pauli Järvinen
  *
  */
 
-angular.module('Music').directive('onEnter', ['$timeout', function ($timeout) {
+angular.module('Music').directive('onEsc', ['$timeout', function ($timeout) {
 	return function (scope, element, attrs) {
 		element.on('keydown keypress', (event) => {
-			if (event.which === 13) {
-				$timeout(() => scope.$eval(attrs.onEnter, {$event: event}));
+			if (event.which === 27) {
+				$timeout(() => scope.$eval(attrs.onEsc, {$event: event}));
 				event.preventDefault();
 			}
 		});

--- a/js/app/services/libraryservice.ts
+++ b/js/app/services/libraryservice.ts
@@ -5,7 +5,7 @@
  * later. See the COPYING file.
  *
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
- * @copyright 2017 - 2023 Pauli Järvinen
+ * @copyright 2017 - 2024 Pauli Järvinen
  *
  */
 
@@ -393,6 +393,8 @@ export class LibraryService {
 			this.#sortByTextField(protoFolders, 'name');
 			// the tracks within each folder are sorted by the file name by the back-end
 
+			const rootFolder = _.find(protoFolders, {parent: null});
+
 			// create temporary look-up-table for the folders to speed up setting up the parent references
 			let foldersLut : {[id: number] : any} = {};
 			_.forEach(protoFolders, (folder) => {
@@ -401,7 +403,10 @@ export class LibraryService {
 
 			_.forEach(protoFolders, (folder) => {
 				// substitute parent id with a reference to the parent folder
-				folder.parent = foldersLut[folder.parent] ?? null;
+				if (folder.parent !== null) {
+					// default to the root folder as NC28 returns bad parent IDs for externally mounted and shared folders
+					folder.parent = foldersLut[folder.parent] ?? rootFolder;
+				}
 				// set parent folder references for the contained tracks
 				_.forEach(folder.tracks, (entry) => entry.track.folder = folder);
 				// init subfolder array

--- a/js/embedded/embeddedplayer.js
+++ b/js/embedded/embeddedplayer.js
@@ -5,7 +5,7 @@
  * later. See the COPYING file.
  *
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
- * @copyright Pauli Järvinen 2017 - 2023
+ * @copyright Pauli Järvinen 2017 - 2024
  */
 
 import playIconPath from '../../img/play-big.svg';
@@ -41,7 +41,7 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 	let pauseButton = null;
 	let prevButton = null;
 	let nextButton = null;
-	let coverImage = null;
+	let coverImageContainer = null;
 	let titleText = null;
 	let artistText = null;
 	let playlistText = null;
@@ -72,7 +72,7 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 
 	function close() {
 		player.stop();
-		musicControls.css('display', 'none');
+		musicControls?.css('display', 'none');
 		$('footer').css('display', ''); // undo hiding the footer in public shares
 		onClose();
 	}
@@ -212,7 +212,9 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 	}
 
 	function createCoverImage() {
-		return $(document.createElement('div')).attr('id', 'albumart');
+		const container = $(document.createElement('div')).attr('id', 'albumart-container');
+		container.append($(document.createElement('div')).attr('id', 'albumart'));
+		return container;
 	}
 
 	function createProgressInfo() {
@@ -302,16 +304,20 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 			text.hide();
 		}
 
-		player.on('loading', function() {
+		function clearProgress() {
 			playTimePreview_tf = null;
 			playTimePreview_ts = null;
 			playTimePreview_s = null;
 			playTime_s = 0;
 			songLength_s = null;
-			loadingShow();
-			updateProgress();
 			bufferBar.css('width', '0');
 			setCursorType('default');
+			updateProgress();
+		}
+
+		player.on('loading', function() {
+			clearProgress();
+			loadingShow();
 		});
 		player.on('ready', function() {
 			loadingHide();
@@ -341,6 +347,10 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 			playButton.css('display', 'inline-block');
 			pauseButton.css('display', 'none');
 			setMediaSessionStatePlaying(false);
+		});
+		player.on('stop', function() {
+			setMediaSessionStatePlaying(false);
+			clearProgress();
 		});
 
 		// Seeking
@@ -492,14 +502,14 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 		pauseButton = createPauseButton();
 		prevButton = createPrevButton();
 		nextButton = createNextButton();
-		coverImage = createCoverImage();
+		coverImageContainer = createCoverImage();
 
 		musicControls.append(createPlaylistArea());
 		musicControls.append(prevButton);
 		musicControls.append(playButton);
 		musicControls.append(pauseButton);
 		musicControls.append(nextButton);
-		musicControls.append(coverImage);
+		musicControls.append(coverImageContainer);
 		musicControls.append(createInfoProgressContainer());
 		musicControls.append(createVolumeControl());
 		musicControls.append(createCloseButton());
@@ -570,7 +580,7 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 		artistText.text(data.artist);
 
 		let cover = data.cover || OC.imagePath('core', 'filetypes/audio');
-		coverImage.css('background-image', 'url("' + cover + '")');
+		coverImageContainer.find(':first-child').css('background-image', 'url("' + cover + '")');
 
 		updateMediaSession(data);
 	}
@@ -601,6 +611,10 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 
 	function changePlayingUrl(playCallback) {
 		player.stop();
+
+		// enable controls which may be disabled while loading a playlist
+		musicControls.find('.control').removeClass('disabled');
+		updateNextButtonStatus();
 
 		musicAppLinkElements().css('cursor', 'default').off('click').attr('title', '');
 		player.trigger('loading');
@@ -710,6 +724,13 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 
 		if (playlistName) {
 			musicControls.addClass('with-playlist');
+			musicControls.find('.control').addClass('disabled');
+			updateMetadata({
+				title: t('music', 'Loading…'),
+				artist: '',
+				cover: null
+			});
+			playlistNumberText.hide();
 			playlistText.text(OCA.Music.Utils.dropFileExtension(playlistName));
 		} else {
 			musicControls.removeClass('with-playlist');
@@ -719,6 +740,16 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 
 		// On NC25, the footer shown on publicly shared folders is laid over the music controls. Get rid of it.
 		$('footer').css('display', 'none');
+	};
+
+	this.showBusy = function(isBusy) {
+		if (isBusy) {
+			coverImageContainer.addClass('icon-loading');
+			$('#menu-container').hide();
+		} else {
+			coverImageContainer.removeClass('icon-loading');
+			$('#menu-container').show();
+		}
 	};
 
 	this.playFile = function(url, mime, fileId, fileName, shareToken = null) {
@@ -763,10 +794,15 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 
 	this.setPlaylistIndex = function(currentIndex, totalCount) {
 		playlistNumberText.text((currentIndex + 1) + ' / ' + totalCount);
+		playlistNumberText.show();
 	};
 
 	this.togglePlayback = togglePlayback;
 
+	this.stop = function() {
+		player.stop();
+	};
+	
 	this.close = close;
 
 	this.setNextAndPrevEnabled = function(enabled) {

--- a/js/embedded/embeddedplayer.js
+++ b/js/embedded/embeddedplayer.js
@@ -523,7 +523,7 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 			let width = parentContainer.width();
 			// On the OC share page and in NC14-24, the parent width has the scroll bar width
 			// already subtracted.
-			if (OCA.Music.Utils.getScrollContainer()[0] === parentContainer[0]) {
+			if (OCA.Music.Utils.getScrollContainer()[0] !== window.document) {
 				width -= OC.Util.getScrollBarWidth();
 			}
 			return width;

--- a/js/embedded/embeddedplayer.js
+++ b/js/embedded/embeddedplayer.js
@@ -511,6 +511,10 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 
 		let parentContainer = $('div#app-content');
 		if (parentContainer.length === 0) {
+			// On NC28, the name and type of the app content container has changed
+			parentContainer = $('main#app-content-vue');
+		}
+		if (parentContainer.length === 0) {
 			// On share page before NC25, there's no #app-content. Use #preview element as parent, instead.
 			parentContainer = $('div#preview');
 			musicControls.css('left', '0');

--- a/js/embedded/embeddedplayer.js
+++ b/js/embedded/embeddedplayer.js
@@ -120,7 +120,7 @@ OCA.Music.EmbeddedPlayer = function(onClose, onNext, onPrev, onMenuOpen, onShowL
 		playlistNumberText = $(document.createElement('span'));
 		area.append(playlistNumberText);
 
-		if (typeof OCA.Music.PlaylistTabView != 'undefined') {
+		if (typeof OCA.Music.playlistTabView != 'undefined') {
 			let menuContainer = $(document.createElement('div')).attr('id', 'menu-container');
 			// "more" button which toggles the popup menu open/closed
 			menuContainer.append($(document.createElement('button'))

--- a/js/embedded/main.js
+++ b/js/embedded/main.js
@@ -9,6 +9,7 @@
  */
 
 import playIconPath from '../../img/play-big.svg';
+import playIconSvgData from '../../img/play-big.svg?raw';
 import playOverlayPath from '../../img/play-overlay.svg';
 
 import { FileAction, registerFileAction } from '@nextcloud/files';
@@ -243,7 +244,7 @@ function initEmbeddedPlayer() {
 		registerFileAction(new FileAction({
 			id: actionId,
 			displayName: () => t('music', 'Play'),
-			iconSvgInline: () => '', // playIconPath,
+			iconSvgInline: () => playIconSvgData,
 
 			enabled: (nodes, _view) => {
 				if (nodes.length !== 1) {

--- a/js/embedded/main.js
+++ b/js/embedded/main.js
@@ -218,8 +218,8 @@ function initEmbeddedPlayer() {
 
 	function connectPlaylistTabViewEvents() {
 		if (OCA.Music.playlistTabView) {
-			OCA.Music.playlistTabView.on('playlistItemClick', (playlistId, playlistName, itemIdx) => {
-				if (mCurrentFile !== null && playlistId == mCurrentFile.id) {
+			OCA.Music.playlistTabView.on('playlistItemClick', (playlistFile, itemIdx) => {
+				if (mCurrentFile !== null && playlistFile.id == mCurrentFile.id) {
 					if (itemIdx == mPlaylist.currentIndex()) {
 						mPlayer.togglePlayback();
 					} else {
@@ -230,11 +230,10 @@ function initEmbeddedPlayer() {
 					if (OCA.Files.App) {
 						// Before NC28
 						mFileList = OCA.Files.App.fileList;
-						mCurrentFile = mFileList.findFile(playlistName);
+						mCurrentFile = mFileList.findFile(playlistFile.name);
 					} else {
 						// NC28 or later
-						// We don't know all of the file details but those are not actually needed for a playlist file
-						mCurrentFile = {id: playlistId, name: playlistName, mimetype: null, path: null};
+						mCurrentFile = playlistFile;
 					}
 					openPlaylistFile(() => jumpToPlaylistFile(mPlaylist.jumpToIndex(itemIdx)));
 				}

--- a/js/embedded/main.js
+++ b/js/embedded/main.js
@@ -54,7 +54,9 @@ function initEmbeddedPlayer() {
 	register();
 
 	function urlForFile(file) {
-		let url = file.url ?? mFileList.getDownloadUrl(file.name, file.path);
+		let url = mFileList
+			? mFileList.getDownloadUrl(file.name, file.path)
+			: OC.filePath('music', '', 'index.php') + '/api/file/' + file.id + '/download';
 
 		// Append request token unless this is a public share. This is actually unnecessary for most files
 		// but needed when the file in question is played using our Aurora.js fallback player.
@@ -289,7 +291,7 @@ function initEmbeddedPlayer() {
 			 */
 			exec: (file, view, dir) => {
 				const adaptFile = (f) => {
-					return {id: f.fileid, name: f.basename, mimetype: f.mime, url: f.source, path: dir};
+					return {id: f.fileid, name: f.basename, mimetype: f.mime, path: dir};
 				};
 				onActionCallback(adaptFile(file));
 
@@ -303,7 +305,7 @@ function initEmbeddedPlayer() {
 						// this is how NC28 seems to do this (older NC versions, on the other hand, used the user-selected UI-language
 						// as the locale for sorting although user-selected locale would have made even more sense).
 						// This still leaves such a mismatch that the special characters may be sorted differently by localeCompare than
-						// what NC28 files does (it uses the 3rd party library natural-orderby for this).
+						// what NC28 Files does (it uses the 3rd party library natural-orderby for this).
 						dirFiles.sort((a, b) => a.name.localeCompare(b.name, undefined, {numeric: true, sensitivity: 'base'}));
 
 						mPlaylist = new OCA.Music.Playlist(dirFiles, mAudioMimes, mCurrentFile.id);

--- a/js/embedded/main.js
+++ b/js/embedded/main.js
@@ -53,6 +53,18 @@ function initEmbeddedPlayer() {
 
 	register();
 
+	function urlForFile(file) {
+		let url = file.url ?? mFileList.getDownloadUrl(file.name, file.path);
+
+		// Append request token unless this is a public share. This is actually unnecessary for most files
+		// but needed when the file in question is played using our Aurora.js fallback player.
+		if (!mShareToken) {
+			let delimiter = _.includes(url, '?') ? '&' : '?';
+			url += delimiter + 'requesttoken=' + encodeURIComponent(OC.requestToken);
+		}
+		return url;
+	}
+
 	function onClose() {
 		mCurrentFile = null;
 		mPlayingListFile = false;
@@ -89,7 +101,7 @@ function initEmbeddedPlayer() {
 
 		// disable/enable the "Import list to Music" item
 		let inLibraryFilesCount = _(mPlaylist.files()).filter('in_library').size();
-		let extStreamsCount = _(mPlaylist.files()).filter('url').size();
+		let extStreamsCount = _(mPlaylist.files()).filter('external').size();
 		let outLibraryFilesCount = mPlaylist.length() - inLibraryFilesCount;
 
 		let $importListItem = $menu.find('#playlist-menu-import');
@@ -171,7 +183,7 @@ function initEmbeddedPlayer() {
 				mPlayer.playExtUrl(file.url, file.caption, mShareToken);
 			} else {
 				mPlayer.playFile(
-					file.url ?? mFileList.getDownloadUrl(file.name, file.path),
+					urlForFile(file),
 					file.mimetype,
 					file.id,
 					file.name,
@@ -277,7 +289,7 @@ function initEmbeddedPlayer() {
 			 */
 			exec: (file, view, dir) => {
 				const adaptFile = (f) => {
-					return {id: f.fileid, name: f.basename, mimetype: f.mime, url: f.source, path: dir}
+					return {id: f.fileid, name: f.basename, mimetype: f.mime, url: f.source, path: dir};
 				};
 				onActionCallback(adaptFile(file));
 

--- a/js/embedded/main.js
+++ b/js/embedded/main.js
@@ -231,11 +231,12 @@ function initEmbeddedPlayer() {
 						// Before NC28
 						mFileList = OCA.Files.App.fileList;
 						mCurrentFile = mFileList.findFile(playlistName);
-						openPlaylistFile(() => jumpToPlaylistFile(mPlaylist.jumpToIndex(itemIdx)));
 					} else {
 						// NC28 or later
-						// TODO
+						// We don't know all of the file details but those are not actually needed for a playlist file
+						mCurrentFile = {id: playlistId, name: playlistName, mimetype: null, path: null};
 					}
+					openPlaylistFile(() => jumpToPlaylistFile(mPlaylist.jumpToIndex(itemIdx)));
 				}
 			});
 			OCA.Music.playlistTabView.on('rendered', () => {

--- a/js/embedded/main.js
+++ b/js/embedded/main.js
@@ -12,7 +12,7 @@ import playIconPath from '../../img/play-big.svg';
 import playIconSvgData from '../../img/play-big.svg?raw';
 import playOverlayPath from '../../img/play-overlay.svg';
 
-import { FileAction, registerFileAction } from '@nextcloud/files';
+import { FileAction, registerFileAction, DefaultType } from '@nextcloud/files';
 
 window.addEventListener('DOMContentLoaded', function() {
 	// Nextcloud 13+ have a built-in Music player in its "individual shared music file" page.
@@ -245,12 +245,13 @@ function initEmbeddedPlayer() {
 			id: actionId,
 			displayName: () => t('music', 'Play'),
 			iconSvgInline: () => playIconSvgData,
+			default: DefaultType.DEFAULT,
+			order: -1, // prioritize over the built-in Viewer app
 
 			enabled: (nodes, _view) => {
 				if (nodes.length !== 1) {
 					return false;
-				}
-		
+				}	
 				return mimes.includes(nodes[0].mime);
 			},
 		
@@ -266,8 +267,6 @@ function initEmbeddedPlayer() {
 				onActionCallback(adaptedFile);
 				return true;
 			},
-
-			default: 'default',
 		}));
 	}
 

--- a/js/embedded/playlisttabview.js
+++ b/js/embedded/playlisttabview.js
@@ -87,9 +87,11 @@ OCA.Music.initPlaylistTabView = function(playlistMimes) {
 		}
 
 		setCurrentTrack(playlistId, trackIndex) {
-			this.$el.find('ol li.current').removeClass('current');
-			if (this.fileInfo && this.fileInfo.id == playlistId) {
-				this.$el.find('ol li#music-playlist-item-' + trackIndex).addClass('current');
+			if (this.$el) {
+				this.$el.find('ol li.current').removeClass('current');
+				if (this.fileInfo && this.fileInfo.id == playlistId) {
+					this.$el.find('ol li#music-playlist-item-' + trackIndex).addClass('current');
+				}
 			}
 		}
 	}

--- a/js/embedded/playlisttabview.js
+++ b/js/embedded/playlisttabview.js
@@ -11,104 +11,134 @@
 OCA.Music = OCA.Music || {};
 
 OCA.Music.initPlaylistTabView = function(playlistMimes) {
-	if (typeof OCA.Files.DetailTabView != 'undefined') {
-		OCA.Music.PlaylistTabView = OCA.Files.DetailTabView.extend({
-			id: 'musicPlaylistTabView',
+
+	class PlaylistTabView {
+		id = 'musicPlaylistTabView';
+		name = t('music', 'Playlist');
+		icon = 'icon-music';
+		$el = null;
+		fileInfo = null;
+
+		enabled(fileInfo) {
+			if (!fileInfo || fileInfo.isDirectory()) {
+				return false;
+			}
+			const mimetype = fileInfo.get('mimetype');
+			return (mimetype && playlistMimes.indexOf(mimetype) > -1);
+		}
+
+		populate(fileInfo) {
+			this.$el.empty(); // erase any previous content
+			this.fileInfo = fileInfo;
+
+			if (fileInfo) {
+	
+				let loadIndicator = $(document.createElement('div')).attr('class', 'loading');
+				this.$el.append(loadIndicator);
+	
+				let onPlaylistLoaded = (data) => {
+					loadIndicator.hide();
+	
+					let list = $(document.createElement('ol'));
+					this.$el.append(list);
+	
+					let titleForFile = function(file) {
+						return file.caption || OCA.Music.Utils.titleFromFilename(file.name);
+					};
+	
+					let tooltipForFile = function(file) {
+						return file.path ? `${file.path}/${file.name}` : file.url;
+					};
+	
+					for (let i = 0; i < data.files.length; ++i) {
+						list.append($(document.createElement('li'))
+									.attr('id', 'music-playlist-item-' + i)
+									.text(titleForFile(data.files[i]))
+									.prop('title', tooltipForFile(data.files[i])));
+					}
+	
+					// click handler
+					list.on('click', 'li', (event) => {
+						let id = event.target.id;
+						let idx = parseInt(id.split('-').pop());
+						this.trigger('playlistItemClick', fileInfo.id, fileInfo.attributes?.name ?? fileInfo.name, idx);
+					});
+	
+					if (data.invalid_paths.length > 0) {
+						this.$el.append($(document.createElement('p')).text(t('music', 'Some files on the playlist were not found') + ':'));
+						let failList = $(document.createElement('ul'));
+						this.$el.append(failList);
+	
+						for (let i = 0; i < data.invalid_paths.length; ++i) {
+							failList.append($(document.createElement('li')).text(data.invalid_paths[i]));
+						}
+					}
+	
+					this.trigger('rendered');
+				};
+	
+				let onError = function(_error) {
+					loadIndicator.hide();
+					this.$el.append($(document.createElement('p')).text(t('music', 'Error reading playlist file')));
+				};
+	
+				OCA.Music.PlaylistFileService.readFile(fileInfo.id, onPlaylistLoaded, onError);
+			}
+		}
+
+		setCurrentTrack(playlistId, trackIndex) {
+			this.$el.find('ol li.current').removeClass('current');
+			if (this.fileInfo && this.fileInfo.id == playlistId) {
+				this.$el.find('ol li#music-playlist-item-' + trackIndex).addClass('current');
+			}
+		}
+	}
+	_.extend(PlaylistTabView.prototype, OC.Backbone.Events);
+
+	// Registration before NC28
+	if (OCA.Files?.DetailTabView) {
+		OCA.Music.playlistTabView = new PlaylistTabView();
+
+		const WrappedPlaylistTabView = OCA.Files.DetailTabView.extend({
+			id: OCA.Music.playlistTabView.id,
 			className: 'tab musicPlaylistTabView',
-
-			getLabel: function() {
-				return t('music', 'Playlist');
-			},
-
-			getIcon: function() {
-				return 'icon-music';
-			},
-
+			getLabel: () => OCA.Music.playlistTabView.name,
+			getIcon: () => OCA.Music.playlistTabView.icon,
+			canDisplay: OCA.Music.playlistTabView.enabled,
 			render: function() {
-				let container = this.$el;
-				container.empty(); // erase any previous content
-
-				let fileInfo = this.getFileInfo();
-
-				if (fileInfo) {
-
-					let loadIndicator = $(document.createElement('div')).attr('class', 'loading');
-					container.append(loadIndicator);
-
-					let onPlaylistLoaded = (data) => {
-						loadIndicator.hide();
-
-						let list = $(document.createElement('ol'));
-						container.append(list);
-
-						let titleForFile = function(file) {
-							return file.caption || OCA.Music.Utils.titleFromFilename(file.name);
-						};
-
-						let tooltipForFile = function(file) {
-							return file.path ? `${file.path}/${file.name}` : file.url;
-						};
-
-						for (let i = 0; i < data.files.length; ++i) {
-							list.append($(document.createElement('li'))
-										.attr('id', 'music-playlist-item-' + i)
-										.text(titleForFile(data.files[i]))
-										.prop('title', tooltipForFile(data.files[i])));
-						}
-
-						// click handler
-						list.on('click', 'li', (event) => {
-							let id = event.target.id;
-							let idx = parseInt(id.split('-').pop());
-							this.trigger('playlistItemClick', fileInfo.id, fileInfo.attributes.name, idx);
-						});
-
-						if (data.invalid_paths.length > 0) {
-							container.append($(document.createElement('p')).text(t('music', 'Some files on the playlist were not found') + ':'));
-							let failList = $(document.createElement('ul'));
-							container.append(failList);
-
-							for (let i = 0; i < data.invalid_paths.length; ++i) {
-								failList.append($(document.createElement('li')).text(data.invalid_paths[i]));
-							}
-						}
-
-						this.trigger('rendered');
-					};
-
-					let onError = function(_error) {
-						loadIndicator.hide();
-						container.append($(document.createElement('p')).text(t('music', 'Error reading playlist file')));
-					};
-
-					OCA.Music.PlaylistFileService.readFile(fileInfo.id, onPlaylistLoaded, onError);
-				}
-			},
-
-			canDisplay: function(fileInfo) {
-				if (!fileInfo || fileInfo.isDirectory()) {
-					return false;
-				}
-				let mimetype = fileInfo.get('mimetype');
-
-				return (mimetype && playlistMimes.indexOf(mimetype) > -1);
-			},
-
-			setCurrentTrack: function(playlistId, trackIndex) {
-				this.$el.find('ol li.current').removeClass('current');
-				let fileInfo = this.getFileInfo();
-				if (fileInfo && fileInfo.id == playlistId) {
-					this.$el.find('ol li#music-playlist-item-' + trackIndex).addClass('current');
-				}
+				OCA.Music.playlistTabView.$el = this.$el;
+				OCA.Music.playlistTabView.populate(this.getFileInfo());
 			}
 		});
-		_.extend(OCA.Music.PlaylistTabView.prototype, OC.Backbone.Events);
-		OCA.Music.playlistTabView = new OCA.Music.PlaylistTabView();
-
 		OC.Plugins.register('OCA.Files.FileList', {
 			attach: function(fileList) {
-				fileList.registerTabView(OCA.Music.playlistTabView);
+				fileList.registerTabView(new WrappedPlaylistTabView());
 			}
 		});
+	}
+
+	// Registration after NC28
+	else if (OCA.Files?.Sidebar) {
+		OCA.Music.playlistTabView = new PlaylistTabView();
+
+		OCA.Files.Sidebar.registerTab(new OCA.Files.Sidebar.Tab({
+			id: OCA.Music.playlistTabView.id,
+			name: OCA.Music.playlistTabView.name,
+			icon: OCA.Music.playlistTabView.icon,
+
+			async mount(el, fileInfo, _context) {
+				OCA.Music.playlistTabView.$el = $(el);
+				OCA.Music.playlistTabView.$el.addClass('musicPlaylistTabView');
+				OCA.Music.playlistTabView.populate(fileInfo);
+			},
+			update(fileInfo) {
+				OCA.Music.playlistTabView.populate(fileInfo);
+			},
+			destroy() {
+			},
+			enabled(fileInfo) {
+				return OCA.Music.playlistTabView.enabled(fileInfo);
+			},
+		}));
 	}
 };

--- a/js/embedded/playlisttabview.js
+++ b/js/embedded/playlisttabview.js
@@ -46,7 +46,7 @@ OCA.Music.initPlaylistTabView = function(playlistMimes) {
 						};
 
 						let tooltipForFile = function(file) {
-							return file.url || `${file.path}/${file.name}`;
+							return file.path ? `${file.path}/${file.name}` : file.url;
 						};
 
 						for (let i = 0; i < data.files.length; ++i) {

--- a/js/embedded/playlisttabview.js
+++ b/js/embedded/playlisttabview.js
@@ -5,7 +5,7 @@
  * later. See the COPYING file.
  *
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
- * @copyright Pauli Järvinen 2020 - 2023
+ * @copyright Pauli Järvinen 2020 - 2024
  */
 
 OCA.Music = OCA.Music || {};
@@ -59,9 +59,17 @@ OCA.Music.initPlaylistTabView = function(playlistMimes) {
 	
 					// click handler
 					list.on('click', 'li', (event) => {
-						let id = event.target.id;
-						let idx = parseInt(id.split('-').pop());
-						this.trigger('playlistItemClick', fileInfo.id, fileInfo.attributes?.name ?? fileInfo.name, idx);
+						// Create struct representing the playlist file in format compatible with the embedded player.
+						// The method fileInfo.get() works consistently on all cloud versions although direct access to
+						// fileInfo properties works differently before and after NC28.
+						const file = {
+							id: fileInfo.get('id'),
+							name: fileInfo.get('name'),
+							mimetype: fileInfo.get('mimetype'),
+							path: fileInfo.get('path'),
+						};
+						const idx = parseInt(event.target.id.split('-').pop());
+						this.trigger('playlistItemClick', file, idx);
 					});
 	
 					if (data.invalid_paths.length > 0) {

--- a/js/shared/utils.ts
+++ b/js/shared/utils.ts
@@ -19,11 +19,20 @@ OCA.Music.Utils = class {
 	/**
 	 * Originally in ownCloud and in Nextcloud up to version 13, the #app-content element acted as the main scroll container.
 	 * Nextcloud 14 changed this so that the document became the main scrollable container, and this needed some adjustments
-	 * to the Music app. Then, Nextcloud 25 changed this back to the original system.
+	 * to the Music app. Then, Nextcloud 25 changed this back to the original system. In Nextcloud 28, this changed once again
+	 * within the Files app but not globally. 
 	 */
 	static getScrollContainer() : JQuery<any> {
 		const appContent = $('#app-content');
-		return (appContent.css('overflow-y') === 'auto') ? appContent : $(window.document);
+		const filesList = $('#app-content-vue .files-list');
+
+		if (appContent.css('overflow-y') === 'auto') {
+			return appContent;
+		} else if (filesList.css('overflow-y') === 'auto') {
+			return filesList;
+		} else {
+			return $(window.document);
+		}
 	}
 
 	/**

--- a/lib/BusinessLayer/TrackBusinessLayer.php
+++ b/lib/BusinessLayer/TrackBusinessLayer.php
@@ -260,14 +260,9 @@ class TrackBusinessLayer extends BusinessLayer {
 				// other user's folder with files shared with this user (mapped under root)
 				$entry = null;
 			} else {
-				$parentId = $folderNode->getParent()->getId();
-				// On NC28, the externally mounted folders have parentId=-1. Map such folders manually under the root folder.
-				if ($parentId == -1) {
-					$parentId = $libRootId;
-				}
 				$entry = [
 					'name' => $folderNode->getName(),
-					'parent' => $parentId
+					'parent' => $folderNode->getParent()->getId()
 				];
 			}
 		}

--- a/lib/BusinessLayer/TrackBusinessLayer.php
+++ b/lib/BusinessLayer/TrackBusinessLayer.php
@@ -244,11 +244,13 @@ class TrackBusinessLayer extends BusinessLayer {
 	}
 
 	private static function getFolderEntry(array $folderNamesAndParents, int $folderId, array $trackIds, Folder $musicFolder) : ?array {
+		$libRootId = $musicFolder->getId();
+
 		if (isset($folderNamesAndParents[$folderId])) {
 			// normal folder within the user home storage
 			$entry = $folderNamesAndParents[$folderId];
 			// special handling for the root folder
-			if ($folderId === $musicFolder->getId()) {
+			if ($folderId === $libRootId) {
 				$entry = null;
 			}
 		} else {
@@ -258,9 +260,14 @@ class TrackBusinessLayer extends BusinessLayer {
 				// other user's folder with files shared with this user (mapped under root)
 				$entry = null;
 			} else {
+				$parentId = $folderNode->getParent()->getId();
+				// On NC28, the externally mounted folders have parentId=-1. Map such folders manually under the root folder.
+				if ($parentId == -1) {
+					$parentId = $libRootId;
+				}
 				$entry = [
 					'name' => $folderNode->getName(),
-					'parent' => $folderNode->getParent()->getId()
+					'parent' => $parentId
 				];
 			}
 		}
@@ -269,7 +276,7 @@ class TrackBusinessLayer extends BusinessLayer {
 			$entry['trackIds'] = $trackIds;
 			$entry['id'] = $folderId;
 
-			if ($entry['id'] == $musicFolder->getId()) {
+			if ($entry['id'] == $libRootId) {
 				// the library root should be reported without a parent folder as that parent does not belong to the library
 				$entry['parent'] = null;
 			}

--- a/lib/Controller/PlaylistApiController.php
+++ b/lib/Controller/PlaylistApiController.php
@@ -355,6 +355,7 @@ class PlaylistApiController extends Controller {
 				if (isset($fileInfo['url'])) {
 					$fileInfo['id'] = $bogusUrlId--;
 					$fileInfo['mimetype'] = null;
+					$fileInfo['external'] = true;
 					return $fileInfo;
 				} else {
 					$file = $fileInfo['file'];
@@ -362,9 +363,11 @@ class PlaylistApiController extends Controller {
 						'id' => $file->getId(),
 						'name' => $file->getName(),
 						'path' => $this->userFolder->getRelativePath($file->getParent()->getPath()),
+						'url' => $this->urlGenerator->linkToRoute('music.api.download', ['fileId' => $file->getId()]),
 						'mimetype' => $file->getMimeType(),
 						'caption' => $fileInfo['caption'],
-						'in_library' => isset($libFileIds[$file->getId()])
+						'in_library' => isset($libFileIds[$file->getId()]),
+						'external' => false
 					];
 				}
 			}, $result['files']);

--- a/lib/Controller/PlaylistApiController.php
+++ b/lib/Controller/PlaylistApiController.php
@@ -363,7 +363,6 @@ class PlaylistApiController extends Controller {
 						'id' => $file->getId(),
 						'name' => $file->getName(),
 						'path' => $this->userFolder->getRelativePath($file->getParent()->getPath()),
-						'url' => $this->urlGenerator->linkToRoute('music.api.download', ['fileId' => $file->getId()]),
 						'mimetype' => $file->getMimeType(),
 						'caption' => $fileInfo['caption'],
 						'in_library' => isset($libFileIds[$file->getId()]),

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -116,7 +116,6 @@ class ShareController extends Controller {
 						'id' => $file->getId(),
 						'name' => $file->getName(),
 						'path' => $sharedFolder->getRelativePath($file->getParent()->getPath()),
-						'url' => 'TODO',
 						'mimetype' => $file->getMimeType(),
 						'caption' => $fileInfo['caption'],
 						'external' => false

--- a/lib/Controller/ShareController.php
+++ b/lib/Controller/ShareController.php
@@ -7,7 +7,7 @@
  * later. See the COPYING file.
  *
  * @author Pauli Järvinen <pauli.jarvinen@gmail.com>
- * @copyright Pauli Järvinen 2018 - 2022
+ * @copyright Pauli Järvinen 2018 - 2023
  */
 
 namespace OCA\Music\Controller;
@@ -108,6 +108,7 @@ class ShareController extends Controller {
 				if (isset($fileInfo['url'])) {
 					$fileInfo['id'] = $bogusUrlId--;
 					$fileInfo['mimetype'] = null;
+					$fileInfo['external'] = true;
 					return $fileInfo;
 				} else {
 					$file = $fileInfo['file'];
@@ -115,8 +116,10 @@ class ShareController extends Controller {
 						'id' => $file->getId(),
 						'name' => $file->getName(),
 						'path' => $sharedFolder->getRelativePath($file->getParent()->getPath()),
+						'url' => 'TODO',
 						'mimetype' => $file->getMimeType(),
-						'caption' => $fileInfo['caption']
+						'caption' => $fileInfo['caption'],
+						'external' => false
 					];
 				}
 			}, $result['files']);

--- a/lib/Utility/HtmlUtil.php
+++ b/lib/Utility/HtmlUtil.php
@@ -90,7 +90,7 @@ class HtmlUtil {
 		$manifest = self::getManifest();
 		$hashedName = \substr($manifest["$name.js"], 0, -3); // the extension is cropped from the name in $manifest
 		if (\method_exists('\OCP\Util', 'addInitScript')) {
-			\OCP\Util::addInitScript('music', '../dist/' . $hashedName);
+			\OCP\Util::/** @scrutinizer ignore-call */addInitScript('music', '../dist/' . $hashedName);
 		} else {
 			\OCP\Util::addScript('music', '../dist/' . $hashedName);
 		}

--- a/lib/Utility/HtmlUtil.php
+++ b/lib/Utility/HtmlUtil.php
@@ -89,7 +89,7 @@ class HtmlUtil {
 	public static function addWebpackScript(string $name) {
 		$manifest = self::getManifest();
 		$hashedName = \substr($manifest["$name.js"], 0, -3); // the extension is cropped from the name in $manifest
-		if (\method_exists('\OCP\Util', 'addInitScript')) {
+		if (\method_exists(\OCP\Util::class, 'addInitScript')) {
 			\OCP\Util::/** @scrutinizer ignore-call */addInitScript('music', '../dist/' . $hashedName);
 		} else {
 			\OCP\Util::addScript('music', '../dist/' . $hashedName);

--- a/lib/Utility/HtmlUtil.php
+++ b/lib/Utility/HtmlUtil.php
@@ -89,7 +89,11 @@ class HtmlUtil {
 	public static function addWebpackScript(string $name) {
 		$manifest = self::getManifest();
 		$hashedName = \substr($manifest["$name.js"], 0, -3); // the extension is cropped from the name in $manifest
-		\OCP\Util::addScript('music', '../dist/' . $hashedName);
+		if (\method_exists('\OCP\Util', 'addInitScript')) {
+			\OCP\Util::addInitScript('music', '../dist/' . $hashedName);
+		} else {
+			\OCP\Util::addScript('music', '../dist/' . $hashedName);
+		}
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "music",
 			"version": "1.9.1",
 			"dependencies": {
+				"@nextcloud/files": "^3.0.0",
 				"angular": "^1.8.3",
 				"angular-gettext": "^2.4.2",
 				"angular-route": "^1.8.3",
@@ -47,6 +48,7 @@
 				"eslint-webpack-plugin": "^4.0.1",
 				"file-loader": "^6.2.0",
 				"mini-css-extract-plugin": "^1.6.2",
+				"path-browserify": "^1.0.1",
 				"style-loader": "^2.0.0",
 				"ts-loader": "^9.4.4",
 				"typescript": "^4.9.5",
@@ -499,7 +501,6 @@
 			"version": "7.23.0",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
 			"integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
-			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1733,6 +1734,14 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@buttercup/fetch": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@buttercup/fetch/-/fetch-0.1.2.tgz",
+			"integrity": "sha512-mDBtsysQ0Gnrp4FamlRJGpu7HUHwbyLC4uUav1I7QAqThFAa/4d1cdZCxrV5gKvh6zO1fu95bILNJi4Y2hALhQ==",
+			"optionalDependencies": {
+				"node-fetch": "^3.3.0"
+			}
+		},
 		"node_modules/@discoveryjs/json-ext": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -2015,6 +2024,150 @@
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
 		},
+		"node_modules/@nextcloud/auth": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-2.2.1.tgz",
+			"integrity": "sha512-zYtgrg9NMZfN8kmL5JPCsh5jDhpTCEslhnZWMvbhTiQ7hrOnji/67ok6VMK0CTJ1a92Vr67Ow72lW7YRX69zEA==",
+			"dependencies": {
+				"@nextcloud/event-bus": "^3.1.0"
+			},
+			"engines": {
+				"node": "^20.0.0",
+				"npm": "^9.0.0"
+			}
+		},
+		"node_modules/@nextcloud/event-bus": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-3.1.0.tgz",
+			"integrity": "sha512-purXQsXbhbmpcDsbDuR0i7vwUgOsqnIUa7QAD3lV/UZUkUT94SmxBM5LgQ8iV8TQBWWleEwQHy5kYfHeTGF9wg==",
+			"dependencies": {
+				"semver": "^7.5.1"
+			},
+			"engines": {
+				"node": "^16.0.0",
+				"npm": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@nextcloud/event-bus/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@nextcloud/event-bus/node_modules/semver": {
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@nextcloud/event-bus/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+		},
+		"node_modules/@nextcloud/files": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/files/-/files-3.0.0.tgz",
+			"integrity": "sha512-zk5oIuVDyk2gWBKCJ+0B1HE3VjhuGnz2iLNbTcbRuTjMYb6aYCAEn1LY0dXbUQG93ehndYJCOdaYri/TaGrlXw==",
+			"dependencies": {
+				"@nextcloud/auth": "^2.2.1",
+				"@nextcloud/l10n": "^2.2.0",
+				"@nextcloud/logger": "^2.7.0",
+				"@nextcloud/paths": "^2.1.0",
+				"@nextcloud/router": "^2.2.0",
+				"is-svg": "^5.0.0",
+				"webdav": "^5.3.0"
+			},
+			"engines": {
+				"node": "^20.0.0",
+				"npm": "^9.0.0"
+			}
+		},
+		"node_modules/@nextcloud/l10n": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/l10n/-/l10n-2.2.0.tgz",
+			"integrity": "sha512-UAM2NJcl/NR46MANSF7Gr7q8/Up672zRyGrxLpN3k4URNmWQM9upkbRME+1K3T29wPrUyOIbQu710ZjvZafqFA==",
+			"dependencies": {
+				"@nextcloud/router": "^2.1.2",
+				"@nextcloud/typings": "^1.7.0",
+				"dompurify": "^3.0.3",
+				"escape-html": "^1.0.3",
+				"node-gettext": "^3.0.0"
+			},
+			"engines": {
+				"node": "^20.0.0",
+				"npm": "^9.0.0"
+			}
+		},
+		"node_modules/@nextcloud/logger": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/logger/-/logger-2.7.0.tgz",
+			"integrity": "sha512-DSJg9H1jT2zfr7uoP4tL5hKncyY+LOuxJzLauj0M/f6gnpoXU5WG1Zw8EFPOrRWjkC0ZE+NCqrMnITgdRRpXJQ==",
+			"dependencies": {
+				"@nextcloud/auth": "^2.0.0",
+				"core-js": "^3.6.4"
+			},
+			"engines": {
+				"node": "^20.0.0",
+				"npm": "^9.0.0"
+			}
+		},
+		"node_modules/@nextcloud/paths": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/paths/-/paths-2.1.0.tgz",
+			"integrity": "sha512-8wX0gqwez0bTuAS8A0OEiqbbp0ZsqLr07zSErmS6OYhh9KZcSt/kO6lQV5tnrFqIqJVsxwz4kHUjtZXh6DSf9Q==",
+			"dependencies": {
+				"core-js": "^3.6.4"
+			}
+		},
+		"node_modules/@nextcloud/router": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/router/-/router-2.2.0.tgz",
+			"integrity": "sha512-M4AVGnB5tt3MYO5RpH/R2jq7z/nW05AmRhk4Lh68krVwRIYGo8pgNikKrPGogHd2Q3UgzF5Py1drHz3uuV99bQ==",
+			"dependencies": {
+				"@nextcloud/typings": "^1.7.0",
+				"core-js": "^3.6.4"
+			},
+			"engines": {
+				"node": "^20.0.0",
+				"npm": "^9.0.0"
+			}
+		},
+		"node_modules/@nextcloud/typings": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-1.7.0.tgz",
+			"integrity": "sha512-fK1i09FYTfSUBdXswyiCr8ng5MwdWjEWOF7hRvNvq5i+XFUSmGjSsRmpQZFM2AONroHqGGQBkvQqpONUshFBJQ==",
+			"dependencies": {
+				"@types/jquery": "3.5.16",
+				"vue": "^2.7.14",
+				"vue-router": "<4"
+			},
+			"engines": {
+				"node": "^16.0.0",
+				"npm": "^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/@nextcloud/typings/node_modules/@types/jquery": {
+			"version": "3.5.16",
+			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.16.tgz",
+			"integrity": "sha512-bsI7y4ZgeMkmpG9OM710RRzDFp+w4P1RGiIt30C1mSBT+ExCleeh4HObwgArnDFELmRrOpXgSYN9VF1hj+f1lw==",
+			"dependencies": {
+				"@types/sizzle": "*"
+			}
+		},
 		"node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
 			"version": "5.1.1-v1",
 			"resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -2197,8 +2350,7 @@
 		"node_modules/@types/sizzle": {
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.4.tgz",
-			"integrity": "sha512-jA2llq2zNkg8HrALI7DtWzhALcVH0l7i89yhY3iBdOz6cBPeACoFq+fkQrjHA39t1hnSFOboZ7A/AY5MMZSlag==",
-			"dev": true
+			"integrity": "sha512-jA2llq2zNkg8HrALI7DtWzhALcVH0l7i89yhY3iBdOz6cBPeACoFq+fkQrjHA39t1hnSFOboZ7A/AY5MMZSlag=="
 		},
 		"node_modules/@types/source-list-map": {
 			"version": "0.1.3",
@@ -2269,6 +2421,16 @@
 			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
 			"integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
 			"dev": true
+		},
+		"node_modules/@vue/compiler-sfc": {
+			"version": "2.7.15",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.15.tgz",
+			"integrity": "sha512-FCvIEevPmgCgqFBH7wD+3B97y7u7oj/Wr69zADBf403Tui377bThTjBvekaZvlRr4IwUAu3M6hYZeULZFJbdYg==",
+			"dependencies": {
+				"@babel/parser": "^7.18.4",
+				"postcss": "^8.4.14",
+				"source-map": "^0.6.1"
+			}
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.11.6",
@@ -2856,8 +3018,12 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+		},
+		"node_modules/base-64": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+			"integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
 		},
 		"node_modules/big.js": {
 			"version": "5.2.2",
@@ -2991,6 +3157,11 @@
 			"dev": true,
 			"peer": true
 		},
+		"node_modules/byte-length": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/byte-length/-/byte-length-1.0.2.tgz",
+			"integrity": "sha512-ovBpjmsgd/teRmgcPh23d4gJvxDoXtAzEL9xTfMU8Yc2kqCDb7L9jAG0XHl1nzuGl+h3ebCIF1i62UFyA9V/2Q=="
+		},
 		"node_modules/call-bind": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3045,6 +3216,14 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/cheerio": {
@@ -3215,6 +3394,14 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/css-loader": {
 			"version": "6.8.1",
 			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.8.1.tgz",
@@ -3305,6 +3492,20 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/csstype": {
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+		},
+		"node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"optional": true,
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/debug": {
@@ -3424,6 +3625,11 @@
 			"dependencies": {
 				"domelementtype": "1"
 			}
+		},
+		"node_modules/dompurify": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.6.tgz",
+			"integrity": "sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w=="
 		},
 		"node_modules/domutils": {
 			"version": "1.5.1",
@@ -3588,6 +3794,11 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "1.0.5",
@@ -4261,6 +4472,27 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
+		"node_modules/fast-xml-parser": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.2.tgz",
+			"integrity": "sha512-rmrXUXwbJedoXkStenj1kkljNF7ugn5ZjR9FJcwmCfcCbtOMDghPajbc+Tck6vE6F5XsDmx+Pr2le9fw8+pXBg==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/naturalintelligence"
+				}
+			],
+			"dependencies": {
+				"strnum": "^1.0.5"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
 		"node_modules/fastest-levenshtein": {
 			"version": "1.0.16",
 			"resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -4277,6 +4509,29 @@
 			"dev": true,
 			"dependencies": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"optional": true,
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
 			}
 		},
 		"node_modules/file-entry-cache": {
@@ -4415,6 +4670,18 @@
 			"dev": true,
 			"dependencies": {
 				"is-callable": "^1.1.3"
+			}
+		},
+		"node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"optional": true,
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
 			}
 		},
 		"node_modules/fs.realpath": {
@@ -4698,6 +4965,14 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/he": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+			"bin": {
+				"he": "bin/he"
+			}
+		},
 		"node_modules/hls.js": {
 			"version": "0.14.17",
 			"resolved": "https://registry.npmjs.org/hls.js/-/hls.js-0.14.17.tgz",
@@ -4706,6 +4981,11 @@
 				"eventemitter3": "^4.0.3",
 				"url-toolkit": "^2.1.6"
 			}
+		},
+		"node_modules/hot-patcher": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/hot-patcher/-/hot-patcher-2.0.1.tgz",
+			"integrity": "sha512-ECg1JFG0YzehicQaogenlcs2qg6WsXQsxtnbr1i696u5tLUjtJdQAh0u2g0Q5YV45f263Ta1GnUJsc8WIfJf4Q=="
 		},
 		"node_modules/htmlparser2": {
 			"version": "3.10.1",
@@ -4931,6 +5211,11 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+		},
 		"node_modules/is-callable": {
 			"version": "1.2.7",
 			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -5122,6 +5407,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-svg": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-svg/-/is-svg-5.0.0.tgz",
+			"integrity": "sha512-sRl7J0oX9yUNamSdc8cwgzh9KBLnQXNzGmW0RVHwg/jEYjGNYHC6UvnYD8+hAeut9WwxRvhG9biK7g/wDGxcMw==",
+			"dependencies": {
+				"fast-xml-parser": "^4.1.3"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-symbol": {
@@ -5407,6 +5706,11 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/layerr": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/layerr/-/layerr-2.0.1.tgz",
+			"integrity": "sha512-z0730CwG/JO24evdORnyDkwG1Q7b7mF2Tp1qRQ0YvrMMARbt1DFG694SOv439Gm7hYKolyZyaB49YIrYIfZBdg=="
+		},
 		"node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -5517,8 +5821,7 @@
 		"node_modules/lodash.get": {
 			"version": "4.4.2",
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-			"dev": true
+			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ=="
 		},
 		"node_modules/lodash.has": {
 			"version": "4.5.2",
@@ -5574,6 +5877,16 @@
 			"dev": true,
 			"dependencies": {
 				"yallist": "^3.0.2"
+			}
+		},
+		"node_modules/md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dependencies": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
 			}
 		},
 		"node_modules/merge-stream": {
@@ -5686,7 +5999,6 @@
 			"version": "3.3.6",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
 			"integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5711,6 +6023,56 @@
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
+		},
+		"node_modules/nested-property": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/nested-property/-/nested-property-4.0.0.tgz",
+			"integrity": "sha512-yFehXNWRs4cM0+dz7QxCd06hTbWbSkV0ISsqBfkntU6TOY4Qm3Q88fRRLOddkGh2Qq6dZvnKVAahfhjcUvLnyA=="
+		},
+		"node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"optional": true,
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"optional": true,
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/node-gettext": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/node-gettext/-/node-gettext-3.0.0.tgz",
+			"integrity": "sha512-/VRYibXmVoN6tnSAY2JWhNRhWYJ8Cd844jrZU/DwLVoI4vBI6ceYbd8i42sYZ9uOgDH3S7vslIKOWV/ZrT2YBA==",
+			"dependencies": {
+				"lodash.get": "^4.4.2"
+			}
 		},
 		"node_modules/node-releases": {
 			"version": "2.0.13",
@@ -5913,6 +6275,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/path-browserify": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+			"integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+			"dev": true
+		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5952,11 +6320,15 @@
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"dev": true
 		},
+		"node_modules/path-posix": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
+			"integrity": "sha512-1gJ0WpNIiYcQydgg3Ed8KzvIqTsDpNwq+cjBCssvBtuTWjEqY1AW+i+OepiEMqDCzyro9B2sLAe4RBPajMYFiA=="
+		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-			"dev": true
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -6107,7 +6479,6 @@
 			"version": "8.4.31",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
 			"integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -6226,6 +6597,11 @@
 			"engines": {
 				"node": ">=6"
 			}
+		},
+		"node_modules/querystringify": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+			"integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
@@ -6390,6 +6766,11 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/requires-port": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+			"integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
 		},
 		"node_modules/resolve": {
 			"version": "1.22.6",
@@ -6707,7 +7088,6 @@
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6716,7 +7096,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6817,6 +7196,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/strnum": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
 		},
 		"node_modules/style-loader": {
 			"version": "2.0.0",
@@ -7366,6 +7750,23 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/url-join": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+			"integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/url-parse": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+			"integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+			"dependencies": {
+				"querystringify": "^2.1.1",
+				"requires-port": "^1.0.0"
+			}
+		},
 		"node_modules/url-toolkit": {
 			"version": "2.2.5",
 			"resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
@@ -7376,6 +7777,20 @@
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true
+		},
+		"node_modules/vue": {
+			"version": "2.7.15",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-2.7.15.tgz",
+			"integrity": "sha512-a29fsXd2G0KMRqIFTpRgpSbWaNBK3lpCTOLuGLEDnlHWdjB8fwl6zyYZ8xCrqkJdatwZb4mGHiEfJjnw0Q6AwQ==",
+			"dependencies": {
+				"@vue/compiler-sfc": "2.7.15",
+				"csstype": "^3.1.0"
+			}
+		},
+		"node_modules/vue-router": {
+			"version": "3.6.5",
+			"resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.6.5.tgz",
+			"integrity": "sha512-VYXZQLtjuvKxxcshuRAwjHnciqZVoXAjTjcqBTz4rKc8qih9g9pI3hbDjmqXaHdgL3v8pV6P8Z335XvHzESxLQ=="
 		},
 		"node_modules/watchpack": {
 			"version": "2.4.0",
@@ -7388,6 +7803,60 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/web-streams-polyfill": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+			"integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+			"optional": true,
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/webdav": {
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/webdav/-/webdav-5.3.1.tgz",
+			"integrity": "sha512-wzZdTHtMuSIXqHGBznc8FM2L94Mc/17Tbn9ppoMybRO0bjWOSIeScdVXWX5qqHsg00EjfiOcwMqGFx6ghIhccQ==",
+			"dependencies": {
+				"@buttercup/fetch": "^0.1.1",
+				"base-64": "^1.0.0",
+				"byte-length": "^1.0.2",
+				"fast-xml-parser": "^4.2.4",
+				"he": "^1.2.0",
+				"hot-patcher": "^2.0.0",
+				"layerr": "^2.0.1",
+				"md5": "^2.3.0",
+				"minimatch": "^7.4.6",
+				"nested-property": "^4.0.0",
+				"path-posix": "^1.0.0",
+				"url-join": "^5.0.0",
+				"url-parse": "^1.5.10"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/webdav/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/webdav/node_modules/minimatch": {
+			"version": "7.4.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+			"integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/webpack": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 	},
 	"bugs": "https://github.com/owncloud/music/issues",
 	"dependencies": {
+		"@nextcloud/files": "^3.0.0",
 		"angular": "^1.8.3",
 		"angular-gettext": "^2.4.2",
 		"angular-route": "^1.8.3",
@@ -49,6 +50,7 @@
 		"eslint-webpack-plugin": "^4.0.1",
 		"file-loader": "^6.2.0",
 		"mini-css-extract-plugin": "^1.6.2",
+		"path-browserify": "^1.0.1",
 		"style-loader": "^2.0.0",
 		"ts-loader": "^9.4.4",
 		"typescript": "^4.9.5",

--- a/templates/main.php
+++ b/templates/main.php
@@ -88,8 +88,6 @@ HtmlUtil::addWebpackStyle('app');
 
 		</div>
 
-		<!-- The following exists just in order to make the core unhide the #searchbox element -->
-		<div id="searchresults" data-appfilter="music"></div>
 	</div>
 
 </div>

--- a/templates/partials/navigation.php
+++ b/templates/partials/navigation.php
@@ -28,7 +28,8 @@ HtmlUtil::printNgTemplate('navigationitem');
 				<div class="label app-navigation-noclose" ng-click="startCreate()" ng-hide="showCreateForm" translate>New Playlist</div>
 				<div class="input-container with-buttons" ng-show="showCreateForm">
 					<input id="new-list-input" type="text" maxlength="256"
-						placeholder="{{ 'New Playlist' | translate }}" on-enter="commitCreate()" on-esc="closeCreate()" ng-model="newPlaylistName" />
+						placeholder="{{ 'New Playlist' | translate }}" ng-model="newPlaylistName"
+						on-enter="commitCreate()" on-esc="closeCreate()" />
 				</div>
 				<div class="actions" ng-show="showCreateForm">
 					<button class="action icon-checkmark app-navigation-noclose"
@@ -51,7 +52,9 @@ HtmlUtil::printNgTemplate('navigationitem');
 				<div class="icon-search" ng-click="startSearch()"></div>
 				<div class="label app-navigation-noclose" ng-click="startSearch()" ng-hide="showSearch" translate>Search</div>
 				<div class="input-container" ng-show="showSearch">
-					<input id="search-input" type="text" placeholder="{{ 'Search' | translate }}" on-esc="clearSearch()" ng-model="searchInput" />
+					<input id="search-input" type="text" placeholder="{{ 'Search' | translate }}"
+						ng-model="searchInput" on-enter="collapseNavigationPaneOnMobile()"
+						on-esc="clearSearch(); collapseNavigationPaneOnMobile()" />
 					<button id="clear-search" class="icon-close" ng-click="clearSearch()"></button>
 				</div>
 			</div>

--- a/templates/partials/navigation.php
+++ b/templates/partials/navigation.php
@@ -25,10 +25,10 @@ HtmlUtil::printNgTemplate('navigationitem');
 			<div id="new-playlist" class="music-navigation-item-content">
 				<div class="icon-add" ng-click="startCreate()" ng-if="!newPlaylistTrackIds.length"></div>
 				<div class="track-count-badge" ng-if="newPlaylistTrackIds.length">{{ newPlaylistTrackIds.length }}</div>
-				<div id="create" class="app-navigation-noclose" ng-click="startCreate()" ng-hide="showCreateForm" translate>New Playlist</div>
-				<div class="input-container" ng-show="showCreateForm">
-					<input type="text" class="new-list" maxlength="256"
-						placeholder="{{ 'New Playlist' | translate }}" on-enter="commitCreate()" ng-model="newPlaylistName" />
+				<div class="label app-navigation-noclose" ng-click="startCreate()" ng-hide="showCreateForm" translate>New Playlist</div>
+				<div class="input-container with-buttons" ng-show="showCreateForm">
+					<input id="new-list-input" type="text" maxlength="256"
+						placeholder="{{ 'New Playlist' | translate }}" on-enter="commitCreate()" on-esc="closeCreate()" ng-model="newPlaylistName" />
 				</div>
 				<div class="actions" ng-show="showCreateForm">
 					<button class="action icon-checkmark app-navigation-noclose"
@@ -44,8 +44,19 @@ HtmlUtil::printNgTemplate('navigationitem');
 			drop-validate="allowDrop(playlist, $data)"
 			drag-hover-class="drag-hover"
 			title="{{ trackCountText(playlist) }}"
-			icon="'playlist'"></li>
-		<li id="music-nav-settings" ng-class="{active: currentView=='#/settings'}">
+			icon="'playlist'">
+		</li>
+		<li id="music-nav-search" class="docked-navigation-item">
+			<div class="music-navigation-item-content">
+				<div class="icon-search" ng-click="startSearch()"></div>
+				<div class="label app-navigation-noclose" ng-click="startSearch()" ng-hide="showSearch" translate>Search</div>
+				<div class="input-container" ng-show="showSearch">
+					<input id="search-input" type="text" placeholder="{{ 'Search' | translate }}" on-esc="clearSearch()" ng-model="searchInput" />
+					<button id="clear-search" class="icon-close" ng-click="clearSearch()"></button>
+				</div>
+			</div>
+		</li>
+		<li id="music-nav-settings" class="docked-navigation-item" ng-class="{active: currentView=='#/settings'}">
 			<a class="" ng-click="navigateTo('#/settings')">
 				<img class="svg" src="<?php HtmlUtil::printSvgPath('settings') ?>">
 				{{ 'Settings' | translate }}

--- a/templates/partials/navigationitem.php
+++ b/templates/partials/navigationitem.php
@@ -15,7 +15,7 @@
 		</div>
 		<span ng-hide="playlist && $parent.showEditForm == playlist.id">{{ text }}</span>
 		<div ng-show="playlist && $parent.showEditForm == playlist.id">
-			<div class="input-container">
+			<div class="input-container with-buttons">
 				<input type="text" class="edit-list" maxlength="256"
 					on-enter="$parent.commitEdit(playlist)" ng-model="playlist.name"/>
 			</div>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,9 @@ module.exports = {
       'lodash': path.resolve('node_modules', 'lodash'),
       'jquery': path.resolve('node_modules', 'jquery/src/jquery'),
       'blueimp-md5': path.resolve('node_modules', 'blueimp-md5'),
+    },
+    fallback: {
+      path: require.resolve("path-browserify")
     }
   },
   plugins: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,6 +72,10 @@ module.exports = {
         }
       },
       {
+        resourceQuery: /raw/,
+        type: 'asset/source',
+      },
+      {
         include: path.resolve('node_modules', 'lodash'),
         parser: { amd: false }
       },


### PR DESCRIPTION
To be fully compatible with Nextcloud 28, quite a few issues need to be fixed.

In the Music app proper:
- [x] Fix the navigation pane layout
- [x] Fix externally mounted folders not showing up in the folders tree view
- [x] Fix shared folders not showing up in the folders tree view
- [x] Add an own input field for the local search within the app
- [x] Check that the event handling still works (e.g. file deleted, file renamed, file shared, file unshared)
- [x] Ensuring that everything still works also on the other Nextcloud and ownCloud versions

In the embedded player within the Files app:
- [x] Opening audio files
- [x] Opening playlist files
- [x] Skipping to next/previous track in the directory order
- [x] Showing the Playlist tab in the details view
- [x] Playing files in a publicly shared folder
- [x] Show the correct icon in the Files actions menu 'Play' item
- [x] Make embedded Music the default action on typical installations (i.e. prioritize over the built-in viewer)
- [x] Show progress animation on long operations (like opening a huge playlist for playing)
- [x] Ensuring that everything still works also on the other Nextcloud and ownCloud versions